### PR TITLE
refactor(processor): allow file path to be passed as string or Path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "monopoly-sg"
-version = "0.4.5"
+version = "0.4.6"
 description = "PDF parsing for Singaporean banks"
 repository = "https://github.com/benjamin-awd/monopoly"
 authors = ["benjamin-awd <benjamindornel@gmail.com>"]

--- a/src/monopoly/examples/single_statement.py
+++ b/src/monopoly/examples/single_statement.py
@@ -6,7 +6,7 @@ def example():
     a single bank statement
     """
     processor = ExampleBankProcessor(
-        file_path="tests/integration/banks/example/input.pdf",
+        file_path="src/monopoly/examples/example_statement.pdf",
     )
 
     # This runs pdftotext on the PDF and

--- a/src/monopoly/processor.py
+++ b/src/monopoly/processor.py
@@ -112,6 +112,9 @@ class StatementProcessor(PdfParser):
         return df
 
     def load(self, df: DataFrame, statement: Statement, output_directory: Path):
+        if isinstance(output_directory, str):
+            output_directory = Path(output_directory)
+
         filename = generate_name(
             file_path=self.file_path,
             format_type="file",

--- a/src/monopoly/processors/base.py
+++ b/src/monopoly/processors/base.py
@@ -29,6 +29,9 @@ class ProcessorBase(StatementProcessor):
         if passwords:
             self.pdf_config.passwords = passwords
 
+        if isinstance(file_path, str):
+            file_path = Path(file_path)
+
         super().__init__(
             statement_config=self.statement_config,
             transaction_config=self.transaction_config,

--- a/tests/unit/test_processor.py
+++ b/tests/unit/test_processor.py
@@ -31,7 +31,7 @@ def test_load(statement, mock_generate_name, mock_to_csv):
     output_path = bank_class.load(df, statement, Path("/output_directory"))
 
     mock_generate_name.assert_called_once_with(
-        file_path="foo",
+        file_path=Path("foo"),
         format_type="file",
         config=statement.statement_config,
         statement_date=datetime(2023, 1, 1),


### PR DESCRIPTION
This allows the user to create the BankProcessor class by passing in a string, instead of a `Path()` type.

e.g. 
```python
    processor = ExampleBankProcessor(
        file_path="src/monopoly/examples/example_statement.pdf",
    )
```

instead of 
```python
    processor = ExampleBankProcessor(
        file_path=Path("src/monopoly/examples/example_statement.pdf"),
    )
```