### PR TITLE
fix: handling for cross-year transactions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "monopoly-sg"
-version = "0.6.3"
+version = "0.6.4"
 description = "PDF parsing for Singaporean banks"
 repository = "https://github.com/benjamin-awd/monopoly"
 authors = ["benjamin-awd <benjamindornel@gmail.com>"]

--- a/src/monopoly/processor.py
+++ b/src/monopoly/processor.py
@@ -59,13 +59,22 @@ class StatementProcessor:
         date_format = statement.statement_config.transaction_date_format
 
         def convert_date(row):
+            """
+            Converts each date to a ISO 8601 (YYYY-MM-DD) format.
+
+            Implements cross-year logic by attributing transactions from
+            October, November, and December to the previous year if
+            the statement month is January.
+            e.g. if the statement month is Jan 2024, transactions from
+            Oct/Nov/Dec should be attributed to the previous year.
+            """
             parsed_date = datetime.strptime(
                 row[StatementFields.TRANSACTION_DATE], date_format
             )
             row_year = statement_date.year
             row_day, row_month = parsed_date.day, parsed_date.month
 
-            if statement_date.month == 1 and row_month == 12:
+            if statement_date.month == 1 and row_month != 1:
                 row_year = statement_date.year - 1
 
             return f"{row_year}-{row_month:02d}-{row_day:02d}"

--- a/tests/integration/banks/test_date_handling.py
+++ b/tests/integration/banks/test_date_handling.py
@@ -12,6 +12,7 @@ def test_transform_cross_year(ocbc: Ocbc, statement: BaseStatement):
         [
             Transaction("12/01", "FAIRPRICE FINEST", "18.49"),
             Transaction("28/12", "DA PAOLO GASTRONOMIA", "19.69"),
+            Transaction("28/11", "KOPITIAM", "5.00"),
         ]
     )
     statement.statement_date = datetime(2024, 1, 1)
@@ -22,6 +23,7 @@ def test_transform_cross_year(ocbc: Ocbc, statement: BaseStatement):
         [
             Transaction("2024-01-12", "FAIRPRICE FINEST", 18.49),
             Transaction("2023-12-28", "DA PAOLO GASTRONOMIA", 19.69),
+            Transaction("2023-11-28", "KOPITIAM", 5.00),
         ]
     )
 


### PR DESCRIPTION
Includes other months i.e. November inside the handling for cross year transactions