### PR TITLE
fix(processor): improve handling for multi-year statements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.7.0
+    rev: 24.1.1
     hooks:
       - id: black
         name: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "monopoly-sg"
-version = "0.7.0"
+version = "0.7.1"
 description = "PDF parsing for Singaporean banks"
 repository = "https://github.com/benjamin-awd/monopoly"
 authors = ["benjamin-awd <benjamindornel@gmail.com>"]

--- a/src/monopoly/processor.py
+++ b/src/monopoly/processor.py
@@ -65,7 +65,7 @@ class StatementProcessor:
             Implements cross-year logic by attributing transactions from
             October, November, and December to the previous year if
             the statement month is January.
-            e.g. if the statement month is Jan 2024, transactions from
+            e.g. if the statement month is Jan/Feb 2024, transactions from
             Oct/Nov/Dec should be attributed to the previous year.
             """
             parsed_date = datetime.strptime(
@@ -74,7 +74,7 @@ class StatementProcessor:
             row_year = statement_date.year
             row_day, row_month = parsed_date.day, parsed_date.month
 
-            if statement_date.month == 1 and row_month != 1:
+            if statement_date.month in (1, 2) and row_month != 1:
                 row_year = statement_date.year - 1
 
             return f"{row_year}-{row_month:02d}-{row_day:02d}"

--- a/tests/unit/test_credit_statement.py
+++ b/tests/unit/test_credit_statement.py
@@ -22,9 +22,9 @@ def test_multiple_prev_month_balance(credit_statement):
 
     pattern = r"(?P<description>LAST MONTH'S BALANCE?)\s+(?P<amount>[\d.,]+)"
     credit_statement.config.prev_balance_pattern = pattern
-    credit_statement.pages[
-        0
-    ].raw_text = "LAST MONTH'S BALANCE   84.89\nfoo\nLAST MONTH'S BALANCE  123.12"
+    credit_statement.pages[0].raw_text = (
+        "LAST MONTH'S BALANCE   84.89\nfoo\nLAST MONTH'S BALANCE  123.12"
+    )
 
     result = credit_statement.prev_month_balance
     assert result == expected


### PR DESCRIPTION
Covers an edge case, where a statement with a statement date of Feb contains transactions from December