### PR TITLE
refactor: rename transaction_date to date on CSV

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "monopoly-sg"
-version = "0.8.1"
+version = "0.8.2"
 description = "PDF parsing for Singaporean banks"
 repository = "https://github.com/benjamin-awd/monopoly"
 authors = ["benjamin-awd <benjamindornel@gmail.com>"]

--- a/src/monopoly/constants.py
+++ b/src/monopoly/constants.py
@@ -28,10 +28,11 @@ class BankNames(AutoEnum):
 
 
 class Columns(AutoEnum):
-    TRANSACTION_DATE = auto()
-    DESCRIPTION = auto()
     AMOUNT = auto()
+    DATE = auto()
+    DESCRIPTION = auto()
     SUFFIX = auto()
+    TRANSACTION_DATE = auto()
 
 
 class SharedPatterns(StrEnum):

--- a/src/monopoly/statements/base.py
+++ b/src/monopoly/statements/base.py
@@ -35,8 +35,9 @@ class BaseStatement(ABC):
         self.pages = parser.get_pages()
         self.config = config
         self.pattern = re.compile(self.config.transaction_pattern)
+        # this replaces `transaction_date` with `date`
         self.columns: list[str] = [
-            Columns.TRANSACTION_DATE,
+            Columns.DATE,
             Columns.DESCRIPTION,
             Columns.AMOUNT,
         ]

--- a/tests/unit/test_load.py
+++ b/tests/unit/test_load.py
@@ -49,7 +49,7 @@ def test_load(
     expected = Path("/output_directory/test_file.csv")
     mock_open.assert_called_once_with(expected, mode="w", encoding="utf8")
     expected_calls = [
-        call.writerow(["transaction_date", "description", "amount"]),
+        call.writerow(["date", "description", "amount"]),
         call.writerow(["2023-01-01", "foo", -100.0]),
         call.writerow(["2023-01-01", "bar", -123.12]),
     ]


### PR DESCRIPTION
This follows the three-column convention that is commonly used by accounting software like QuickBooks

![image](https://github.com/benjamin-awd/monopoly/assets/62495124/7c2738a1-4b98-4cc6-84c8-e8451f497da6)
