### PR TITLE
refactor(banks,config): use global password array

### DIFF
--- a/src/monopoly/banks/base.py
+++ b/src/monopoly/banks/base.py
@@ -2,8 +2,6 @@ import logging
 from abc import ABC, abstractmethod
 from typing import Optional
 
-from pydantic import SecretStr
-
 from monopoly.config import CreditStatementConfig, DebitStatementConfig, PdfConfig
 from monopoly.constants import EncryptionIdentifier, MetadataIdentifier
 
@@ -46,9 +44,3 @@ class BankBase(ABC):
     @abstractmethod
     def identifiers(self) -> list[EncryptionIdentifier | MetadataIdentifier]:
         raise NotImplementedError("Identifiers must be defined")
-
-    @property
-    def passwords(self) -> Optional[list[SecretStr]]:
-        if self.passwords:
-            return self.passwords
-        return None

--- a/src/monopoly/banks/citibank/citibank.py
+++ b/src/monopoly/banks/citibank/citibank.py
@@ -1,6 +1,6 @@
 import logging
 
-from monopoly.config import CreditStatementConfig, PdfConfig, passwords
+from monopoly.config import CreditStatementConfig, PdfConfig
 from monopoly.constants import (
     BankNames,
     CreditTransactionPatterns,
@@ -32,5 +32,3 @@ class Citibank(BankBase):
             producer="Ricoh Americas Corporation, AFP2PDF",
         )
     ]
-
-    passwords = passwords.citibank_pdf_passwords

--- a/src/monopoly/banks/hsbc/hsbc.py
+++ b/src/monopoly/banks/hsbc/hsbc.py
@@ -1,6 +1,6 @@
 import logging
 
-from monopoly.config import CreditStatementConfig, PdfConfig, passwords
+from monopoly.config import CreditStatementConfig, PdfConfig
 from monopoly.constants import (
     BankNames,
     CreditTransactionPatterns,
@@ -36,5 +36,3 @@ class Hsbc(BankBase):
             creator="OpenText Exstream",
         ),
     ]
-
-    passwords = passwords.hsbc_pdf_passwords

--- a/src/monopoly/banks/ocbc/ocbc.py
+++ b/src/monopoly/banks/ocbc/ocbc.py
@@ -1,6 +1,6 @@
 import logging
 
-from monopoly.config import CreditStatementConfig, DebitStatementConfig, passwords
+from monopoly.config import CreditStatementConfig, DebitStatementConfig
 from monopoly.constants import (
     BankNames,
     CreditTransactionPatterns,
@@ -39,5 +39,3 @@ class Ocbc(BankBase):
             creator="pdfgen", producer="Streamline PDFGen for OCBC Group"
         ),
     ]
-
-    passwords = passwords.ocbc_pdf_passwords

--- a/src/monopoly/banks/standard_chartered/standard_chartered.py
+++ b/src/monopoly/banks/standard_chartered/standard_chartered.py
@@ -1,6 +1,6 @@
 import logging
 
-from monopoly.config import CreditStatementConfig, PdfConfig, passwords
+from monopoly.config import CreditStatementConfig, PdfConfig
 from monopoly.constants import (
     BankNames,
     CreditTransactionPatterns,
@@ -32,5 +32,3 @@ class StandardChartered(BankBase):
             producer="iText",
         )
     ]
-
-    passwords = passwords.standard_chartered_pdf_passwords

--- a/src/monopoly/config.py
+++ b/src/monopoly/config.py
@@ -9,22 +9,14 @@ from monopoly.constants import BankNames, InternalBankNames
 
 
 class PdfPasswords(BaseSettings):
-    ocbc_pdf_passwords: list[SecretStr] = [SecretStr("")]
-    citibank_pdf_passwords: list[SecretStr] = [SecretStr("")]
-    standard_chartered_pdf_passwords: list[SecretStr] = [SecretStr("")]
-    hsbc_pdf_passwords: list[SecretStr] = [SecretStr("")]
-
-    model_config = SettingsConfigDict(env_file=".env", extra="allow")
-
-
-class Passwords(BaseSettings):
     """
     Pydantic model that automatically populates variables from a .env file,
     or an environment variable called `passwords`.
-    e.g. export PASSWORDS='{"OCBC_PDF_PASSWORDS": ...}'
+    e.g. export PDF_PASSWORDS='["password123", "secretpass"]'
     """
 
-    passwords: PdfPasswords = PdfPasswords()
+    pdf_passwords: list[SecretStr] = [SecretStr("")]
+    model_config = SettingsConfigDict(env_file=".env", extra="allow")
 
 
 @dataclass(frozen=True)
@@ -116,4 +108,4 @@ class PdfConfig:
     page_bbox: Optional[tuple[float, float, float, float]] = None
 
 
-passwords = Passwords().passwords
+passwords = PdfPasswords().pdf_passwords

--- a/src/monopoly/pdf.py
+++ b/src/monopoly/pdf.py
@@ -10,6 +10,7 @@ import pdftotext
 from pydantic import SecretStr
 
 from monopoly.banks import BankBase
+from monopoly.config import passwords as env_passwords
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +64,7 @@ class PdfParser:
     @property
     def passwords(self):
         if not self._passwords:
-            return self.bank.passwords
+            return env_passwords
         return self._passwords
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 import fitz
@@ -7,6 +8,13 @@ from monopoly.config import CreditStatementConfig, DateOrder, PdfConfig
 from monopoly.handler import StatementHandler
 from monopoly.pdf import PdfPage, PdfParser
 from monopoly.statements import BaseStatement, CreditStatement, DebitStatement
+
+
+@pytest.fixture
+def mock_env():
+    """Prevents existing environment variables from interfering with tests"""
+    with patch.dict(os.environ, clear=True):
+        yield
 
 
 @pytest.fixture

--- a/tests/integration/test_parser.py
+++ b/tests/integration/test_parser.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest.mock import PropertyMock, patch
 
 from pydantic import SecretStr
 from pytest import raises
@@ -67,9 +68,14 @@ def test_error_raised_if_override_is_wrong(parser: PdfParser):
 
 def test_missing_password_raises_error(parser: PdfParser):
     parser.file_path = fixture_directory / "protected.pdf"
-
-    with raises(MissingPasswordError, match="No password found in PDF configuration"):
-        parser.open()
+    with patch(
+        "monopoly.pdf.PdfParser.passwords", new_callable=PropertyMock
+    ) as mock_passwords:
+        mock_passwords.return_value = None
+        with raises(
+            MissingPasswordError, match="No password found in PDF configuration"
+        ):
+            parser.open()
 
 
 def test_null_password_raises_error(parser: PdfParser):

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -1,49 +1,29 @@
 import os
-from textwrap import dedent
-from unittest import mock
 
 import pytest
 
-from monopoly.config import Passwords, PdfPasswords
-
-
-@pytest.fixture
-def mock_env():
-    with mock.patch.dict(os.environ, clear=True):
-        yield
+from monopoly.config import PdfPasswords
 
 
 @pytest.fixture
 def create_temporary_env_file(tmp_path):
     env_file = tmp_path / ".env"
-    env_content = dedent(
-        """
-    OCBC_PDF_PASSWORDS=["password1", "password2"]
-    HSBC_PDF_PASSWORDS=["hsbc_password"]
-    """
-    )
+    env_content = 'PDF_PASSWORDS=["passwordfoo", "passwordbar"]'
     env_file.write_text(env_content)
     return str(env_file)
 
 
 def test_load_from_environment_variable():
-    os.environ["PASSWORDS"] = '{"OCBC_PDF_PASSWORDS": ["password1", "password2"]}'
+    os.environ["PDF_PASSWORDS"] = '["password1", "password2"]'
     expected_passwords = ["password1", "password2"]
+    passwords = PdfPasswords().pdf_passwords
 
-    passwords = Passwords().passwords
-    assert [
-        pw.get_secret_value() for pw in passwords.ocbc_pdf_passwords
-    ] == expected_passwords
+    assert [pw.get_secret_value() for pw in passwords] == expected_passwords
 
 
-def test_load_from_env_file(create_temporary_env_file, mock_env):
+@pytest.mark.usefixtures("mock_env")
+def test_load_from_env_file(create_temporary_env_file):
     env_file = create_temporary_env_file
-    settings = PdfPasswords(_env_file=env_file)
-    expected_ocbc_passwords = ["password1", "password2"]
-    expected_hsbc_passwords = ["hsbc_password"]
-    assert [
-        pw.get_secret_value() for pw in settings.ocbc_pdf_passwords
-    ] == expected_ocbc_passwords
-    assert [
-        pw.get_secret_value() for pw in settings.hsbc_pdf_passwords
-    ] == expected_hsbc_passwords
+    passwords = PdfPasswords(_env_file=env_file).pdf_passwords
+    expected_passwords = ["passwordfoo", "passwordbar"]
+    assert [pw.get_secret_value() for pw in passwords] == expected_passwords


### PR DESCRIPTION
This PR decouples password related logic from the bank classes, and instead stores passwords in a single array.

Based on discussions from https://github.com/benjamin-awd/monopoly/issues/143, https://github.com/benjamin-awd/monopoly/issues/144 

Users that have a large number of passwords / statements (to the point where performance is impacted) should run monopoly like so:
```sh
PDF_PASSWORDS=['<specific password>'] monopoly specific_statement_dir &
PDF_PASSWORDS=['<other password>'] monopoly other_dir
```