### PR TITLE
refactor(write): generate hash based on transactions

### DIFF
--- a/src/monopoly/pipeline.py
+++ b/src/monopoly/pipeline.py
@@ -130,7 +130,7 @@ class Pipeline:
             output_directory = Path(output_directory)
 
         filename = generate_name(
-            document=statement.document,
+            statement=statement,
             format_type="file",
             statement_config=statement.config,
             statement_type=statement.statement_type,

--- a/src/monopoly/write.py
+++ b/src/monopoly/write.py
@@ -1,23 +1,22 @@
 from datetime import datetime
 from hashlib import sha256
 
-from fitz import Document
-
 from monopoly.config import StatementConfig
+from monopoly.statements import CreditStatement, DebitStatement
 
 
-def generate_hash(document: Document) -> str:
+def generate_hash(statement: CreditStatement | DebitStatement) -> str:
     """
     Generates a hash based on PDF metadata
     """
     hash_object = sha256()
-    hash_object.update(str(document.metadata).encode("utf-8"))
+    hash_object.update(str(statement.transactions).encode("utf-8"))
     file_hash = hash_object.hexdigest()[0:6]
     return file_hash
 
 
 def generate_name(
-    document: Document,
+    statement: CreditStatement | DebitStatement,
     format_type: str,
     statement_config: StatementConfig,
     statement_type: str,
@@ -35,7 +34,7 @@ def generate_name(
     bank_name = statement_config.bank_name
     year = statement_date.year
     month = statement_date.month
-    file_uuid = generate_hash(document)
+    file_uuid = generate_hash(statement)
 
     filename = f"{bank_name}-{statement_type}-{year}-{month:02d}-{file_uuid}.csv"
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -93,7 +93,7 @@ def test_monopoly_output(cli_runner: CliRunner):
 
         assert result.exit_code == 0
         assert "1 statement(s) processed" in result.output
-        assert "input.pdf -> example-credit-2023-07-9a7ca0.csv" in result.output
+        assert "input.pdf -> example-credit-2023-07-ae15d6.csv" in result.output
 
 
 def test_monopoly_no_pdf(cli_runner: CliRunner):

--- a/tests/unit/test_generate_name.py
+++ b/tests/unit/test_generate_name.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
-from fitz import Document
 
 from monopoly.config import StatementConfig
 from monopoly.write import generate_name
@@ -17,7 +16,7 @@ def mock_generate_hash():
 
 @pytest.mark.usefixtures("mock_generate_hash")
 def test_generate_name():
-    document = MagicMock(spec=Document)
+    statement = MagicMock()
     statement_config = MagicMock(spec=StatementConfig)
     statement_config.bank_name = "hsbc"
     statement_date = datetime(2023, 6, 15)
@@ -26,7 +25,7 @@ def test_generate_name():
     expected_filename = "hsbc-credit-2023-06-b960bf1e.csv"
     # Test for format_type="file"
     filename = generate_name(
-        document=document,
+        statement=statement,
         format_type="file",
         statement_config=statement_config,
         statement_type=statement_type,
@@ -36,7 +35,7 @@ def test_generate_name():
 
     # Test for format_type="blob"
     filename = generate_name(
-        document=document,
+        statement=statement,
         format_type="blob",
         statement_config=statement_config,
         statement_type=statement_type,
@@ -50,7 +49,7 @@ def test_generate_name():
     # Test for invalid format_type
     with pytest.raises(ValueError, match="Invalid format_type"):
         generate_name(
-            document=document,
+            statement=statement,
             format_type="invalid_format",
             statement_config=statement_config,
             statement_type=statement_type,


### PR DESCRIPTION
Since document metadata creation data will change each time the PDF is reloaded, even though the file contents remain the same -- better to use the transactions instead