### PR TITLE
Remove encryption identifier

### DIFF
--- a/src/monopoly/banks/dbs/dbs.py
+++ b/src/monopoly/banks/dbs/dbs.py
@@ -7,11 +7,7 @@ from monopoly.constants import (
     DebitTransactionPatterns,
     StatementBalancePatterns,
 )
-from monopoly.identifiers import (
-    EncryptionIdentifier,
-    MetadataIdentifier,
-    TextIdentifier,
-)
+from monopoly.identifiers import MetadataIdentifier, TextIdentifier
 
 from ..base import BankBase
 
@@ -36,12 +32,6 @@ class Dbs(BankBase):
     )
 
     identifiers = [
-        [
-            EncryptionIdentifier(
-                pdf_version=1.4, algorithm=2, revision=3, length=128, permissions=-1852
-            ),
-            MetadataIdentifier(creator="Quadient CXM AG"),
-        ],
         [
             TextIdentifier("DBS"),
             MetadataIdentifier(creator="Quadient CXM AG"),

--- a/src/monopoly/banks/hsbc/hsbc.py
+++ b/src/monopoly/banks/hsbc/hsbc.py
@@ -6,11 +6,7 @@ from monopoly.constants import (
     CreditTransactionPatterns,
     StatementBalancePatterns,
 )
-from monopoly.identifiers import (
-    EncryptionIdentifier,
-    MetadataIdentifier,
-    TextIdentifier,
-)
+from monopoly.identifiers import MetadataIdentifier, TextIdentifier
 
 from ..base import BankBase
 
@@ -31,16 +27,6 @@ class Hsbc(BankBase):
     )
 
     identifiers = [
-        [
-            EncryptionIdentifier(
-                pdf_version=1.6, algorithm=4, revision=4, length=128, permissions=-1804
-            ),
-            MetadataIdentifier(
-                title="PRJ_BEAGLE_ST_CNS_SGH_APP_Orchid",
-                author="Registered to: HSBCGLOB",
-                creator="OpenText Exstream",
-            ),
-        ],
         [
             MetadataIdentifier(
                 title="PRJ_BEAGLE_ST_CNS_SGH_APP_Orchid",

--- a/src/monopoly/banks/maybank/maybank.py
+++ b/src/monopoly/banks/maybank/maybank.py
@@ -7,7 +7,7 @@ from monopoly.constants import (
     DebitTransactionPatterns,
     StatementBalancePatterns,
 )
-from monopoly.identifiers import EncryptionIdentifier, MetadataIdentifier
+from monopoly.identifiers import MetadataIdentifier
 
 from ..base import BankBase
 
@@ -40,9 +40,6 @@ class Maybank(BankBase):
             ),
         ],
         [
-            EncryptionIdentifier(
-                pdf_version=1.4, algorithm=4, revision=4, length=128, permissions=-1852
-            ),
             MetadataIdentifier(
                 title="Credit Card Statement",
                 author="Maybank2U.com",

--- a/src/monopoly/banks/ocbc/ocbc.py
+++ b/src/monopoly/banks/ocbc/ocbc.py
@@ -7,11 +7,7 @@ from monopoly.constants import (
     DebitTransactionPatterns,
     StatementBalancePatterns,
 )
-from monopoly.identifiers import (
-    EncryptionIdentifier,
-    MetadataIdentifier,
-    TextIdentifier,
-)
+from monopoly.identifiers import MetadataIdentifier, TextIdentifier
 
 from ..base import BankBase
 
@@ -35,22 +31,6 @@ class Ocbc(BankBase):
     )
 
     identifiers = [
-        [
-            EncryptionIdentifier(
-                pdf_version=1.4, algorithm=4, revision=4, length=128, permissions=-1036
-            ),
-            MetadataIdentifier(
-                creator="pdfgen", producer="Streamline PDFGen for OCBC Group"
-            ),
-        ],
-        [
-            EncryptionIdentifier(
-                pdf_version=1.4, algorithm=2, revision=3, length=128, permissions=-1796
-            ),
-            MetadataIdentifier(
-                creator="pdfgen", producer="Streamline PDFGen for OCBC Group"
-            ),
-        ],
         [
             MetadataIdentifier(
                 creator="pdfgen", producer="Streamline PDFGen for OCBC Group"

--- a/src/monopoly/banks/standard_chartered/standard_chartered.py
+++ b/src/monopoly/banks/standard_chartered/standard_chartered.py
@@ -6,7 +6,7 @@ from monopoly.constants import (
     CreditTransactionPatterns,
     StatementBalancePatterns,
 )
-from monopoly.identifiers import MetadataIdentifier
+from monopoly.identifiers import MetadataIdentifier, TextIdentifier
 
 from ..base import BankBase
 
@@ -31,6 +31,7 @@ class StandardChartered(BankBase):
             MetadataIdentifier(
                 title="eStatement",
                 producer="iText",
-            )
+            ),
+            TextIdentifier("Standard Chartered"),
         ]
     ]


### PR DESCRIPTION
Doesn't work well in downstream -- since the encryption dictionary is often stripped, this means that two sets of identifiers need to be maintained (the metadata base, and the metadata base + encryption)