### PR TITLE
refactor(banks): remove EncryptionIdentifier

### DIFF
--- a/src/monopoly/bank_detector.py
+++ b/src/monopoly/bank_detector.py
@@ -1,39 +1,13 @@
 import logging
-from dataclasses import Field, dataclass, field, fields
+from dataclasses import Field, fields
 from functools import cached_property
 from typing import Any, Type
 
-import fitz
-
 from monopoly.banks import BankBase, banks
-from monopoly.identifiers import (
-    EncryptionIdentifier,
-    Identifier,
-    MetadataIdentifier,
-    TextIdentifier,
-)
+from monopoly.identifiers import Identifier, MetadataIdentifier, TextIdentifier
 from monopoly.pdf import PdfDocument
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class EncryptDict:
-    """Stores encryption dictionary of a PDF"""
-
-    raw_encrypt_dict: dict
-    pdf_version: str
-    algorithm: int = field(init=False)
-    length: int = field(init=False)
-    permissions: int = field(init=False)
-    revision: int = field(init=False)
-
-    def __post_init__(self):
-        self.pdf_version = float(self.pdf_version[-3:])
-        self.algorithm = int(self.raw_encrypt_dict.get("V"))
-        self.length = int(self.raw_encrypt_dict.get("Length"))
-        self.permissions = int(self.raw_encrypt_dict.get("P"))
-        self.revision = int(self.raw_encrypt_dict.get("R"))
 
 
 class BankDetector:
@@ -46,17 +20,6 @@ class BankDetector:
         Retrieves encryption and metadata identifiers from a bank statement PDF
         """
         identifiers: list[Identifier] = []
-        if encrypt_dict := self.encrypt_dict:
-            encryption_identifier = EncryptionIdentifier(
-                float(encrypt_dict.pdf_version),
-                encrypt_dict.algorithm,
-                encrypt_dict.revision,
-                encrypt_dict.length,
-                encrypt_dict.permissions,
-            )
-            logger.debug("Found encryption identifier: %s", encryption_identifier)
-            identifiers.append(encryption_identifier)
-
         if metadata := self.document.open().metadata:
             metadata_identifier = MetadataIdentifier(**metadata)
             identifiers.append(metadata_identifier)
@@ -65,34 +28,6 @@ class BankDetector:
             raise ValueError("Could not get identifier")
 
         return identifiers
-
-    @cached_property
-    def encrypt_dict(self) -> EncryptDict | None:
-        document = self.document.open()
-        stream = self.document.get_byte_stream()
-        pdf_version_string = stream.read(8).decode("utf-8", "backslashreplace")
-        try:
-            raw_encrypt_dict = self.get_raw_encrypt_dict(document)
-            encrypt_dict = EncryptDict(raw_encrypt_dict, pdf_version_string)
-            return encrypt_dict
-        except TypeError:
-            return None
-
-    @staticmethod
-    def get_raw_encrypt_dict(doc: fitz.Document) -> dict:
-        """
-        Helper function to extract the PDF encryption dictionary, since
-        `fitz` doesn't provide it
-        """
-        encrypt_metadata = {}
-        pdf_object, value = doc.xref_get_key(-1, "Encrypt")
-        if pdf_object != "xref":
-            pass  # PDF has no metadata
-        else:
-            xref = int(value.replace("0 R", ""))  # extract the metadata xref
-            for key in doc.xref_get_keys(xref):
-                encrypt_metadata[key] = doc.xref_get_key(xref, key)[1]
-        return encrypt_metadata
 
     def detect_bank(self) -> Type[BankBase] | None:
         """

--- a/src/monopoly/identifiers.py
+++ b/src/monopoly/identifiers.py
@@ -7,17 +7,6 @@ class Identifier:
 
 
 @dataclass
-class EncryptionIdentifier(Identifier):
-    """Stores encryption-related data taken from the encryption dictionary of a PDF"""
-
-    pdf_version: float
-    algorithm: int
-    revision: int
-    length: int
-    permissions: int
-
-
-@dataclass
 class MetadataIdentifier(Identifier):
     """Stores the metadata attributes of a PDF"""
 

--- a/tests/unit/test_bank_identifier/test_auto_detect_bank.py
+++ b/tests/unit/test_bank_identifier/test_auto_detect_bank.py
@@ -4,11 +4,7 @@ import pytest
 
 from monopoly.bank_detector import BankDetector
 from monopoly.banks.base import BankBase
-from monopoly.identifiers import (
-    EncryptionIdentifier,
-    MetadataIdentifier,
-    TextIdentifier,
-)
+from monopoly.identifiers import MetadataIdentifier, TextIdentifier
 from monopoly.pdf import PdfDocument
 
 
@@ -27,9 +23,6 @@ class MockBankOne(BankBase):
     credit_config = None
     identifiers = [
         [
-            EncryptionIdentifier(
-                pdf_version=1.7, algorithm=5, revision=6, length=256, permissions=-1028
-            ),
             MetadataIdentifier(creator="foo", producer="bar"),
         ]
     ]
@@ -58,9 +51,6 @@ class MockBankWithMultipleTextIdentifier(BankBase):
     credit_config = None
     identifiers = [
         [
-            EncryptionIdentifier(
-                pdf_version=1.7, algorithm=5, revision=6, length=256, permissions=-1028
-            ),
             MetadataIdentifier(creator="foo", producer="bar"),
             TextIdentifier("specific_string"),
             TextIdentifier("other_specific_string"),
@@ -122,9 +112,6 @@ def test_detect_bank_with_text_identifier(
 ):
     mock_raw_text.return_value = "specific_string, other_specific_string"
     mock_metadata_items.return_value = [
-        EncryptionIdentifier(
-            pdf_version=1.7, algorithm=5, revision=6, length=256, permissions=-1028
-        ),
         MetadataIdentifier(creator="foo", producer="bar"),
     ]
 
@@ -143,9 +130,6 @@ def test_detect_bank_with_not_matching_text_identifier(
 ):
     mock_raw_text.return_value = "not_a_match"
     mock_metadata_items.return_value = [
-        EncryptionIdentifier(
-            pdf_version=1.7, algorithm=5, revision=6, length=256, permissions=-1028
-        ),
         MetadataIdentifier(creator="foo", producer="bar"),
     ]
 

--- a/tests/unit/test_bank_identifier/test_check_matching_field.py
+++ b/tests/unit/test_bank_identifier/test_check_matching_field.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock
 
 from monopoly.bank_detector import BankDetector
-from monopoly.identifiers import EncryptionIdentifier, MetadataIdentifier
+from monopoly.identifiers import MetadataIdentifier
 
 
 def test_check_metadata_identifier_field_exact_match(
@@ -12,22 +12,6 @@ def test_check_metadata_identifier_field_exact_match(
     field.type = str
     metadata = MetadataIdentifier(title="statement")
     identifier = MetadataIdentifier(title="statement")
-
-    assert metadata_analyzer.check_matching_field(field, metadata, identifier)
-
-
-def test_check_encryption_identifier_field_exact_match(
-    metadata_analyzer: BankDetector,
-):
-    field = Mock()
-    field.name = "pdf_version"
-    field.type = float
-    metadata = EncryptionIdentifier(
-        pdf_version=9.0, algorithm=1, revision=2, length=3, permissions=4
-    )
-    identifier = EncryptionIdentifier(
-        pdf_version=9.0, algorithm=1, revision=2, length=3, permissions=4
-    )
 
     assert metadata_analyzer.check_matching_field(field, metadata, identifier)
 

--- a/tests/unit/test_bank_identifier/test_get_identifier.py
+++ b/tests/unit/test_bank_identifier/test_get_identifier.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from monopoly.bank_detector import BankDetector
-from monopoly.identifiers import EncryptionIdentifier, MetadataIdentifier
+from monopoly.identifiers import MetadataIdentifier
 from monopoly.pdf import PdfDocument
 
 
@@ -55,19 +55,6 @@ def mock_non_encrypted_document():
             "producer": "",
         },
     )
-
-
-def test_encryption_identifier(mock_encrypted_document):
-    with patch("monopoly.bank_detector.BankDetector.get_raw_encrypt_dict") as mock:
-        metadata_analyzer = BankDetector(mock_encrypted_document)
-        mock.return_value = {"V": "4", "R": "4", "Length": "128", "P": "-1804"}
-
-        expected_identifier = EncryptionIdentifier(
-            pdf_version=1.6, algorithm=4, revision=4, length=128, permissions=-1804
-        )
-
-        assert isinstance(metadata_analyzer.metadata_items[0], EncryptionIdentifier)
-        assert metadata_analyzer.metadata_items[0] == expected_identifier
 
 
 def test_metadata_identifier(mock_non_encrypted_document):


### PR DESCRIPTION
Previously, the EncryptionIdentifier class was used to decide which password map to use.

Since passwords are now stored in a single array, this logic is moot and should now be removed.