### PR TITLE
refactor: use header patterns to identify statement type

### DIFF
--- a/src/monopoly/banks/citibank/citibank.py
+++ b/src/monopoly/banks/citibank/citibank.py
@@ -17,6 +17,7 @@ class Citibank(BankBase):
     credit_config = CreditStatementConfig(
         bank_name=BankNames.CITIBANK,
         statement_date_pattern=r"Statement\sDate\s+(.*)",
+        header_pattern=r"(DATE.*DESCRIPTION.*AMOUNT)",
         prev_balance_pattern=StatementBalancePatterns.CITIBANK,
         transaction_pattern=CreditTransactionPatterns.CITIBANK,
     )

--- a/src/monopoly/banks/dbs/dbs.py
+++ b/src/monopoly/banks/dbs/dbs.py
@@ -19,6 +19,7 @@ class Dbs(BankBase):
         bank_name=BankNames.DBS,
         statement_date_pattern=r"(\d{2}\s[A-Za-z]{3}\s\d{4})",
         multiline_transactions=False,
+        header_pattern=r"(DATE.*DESCRIPTION.*AMOUNT)",
         transaction_pattern=CreditTransactionPatterns.DBS,
         prev_balance_pattern=StatementBalancePatterns.DBS,
     )
@@ -27,7 +28,7 @@ class Dbs(BankBase):
         bank_name=BankNames.DBS,
         statement_date_pattern=r"(\d{2}\s[A-Za-z]{3}\s\d{4})",
         multiline_transactions=True,
-        debit_statement_identifier=r"(WITHDRAWAL.*DEPOSIT.*BALANCE)",
+        header_pattern=r"(WITHDRAWAL.*DEPOSIT.*BALANCE)",
         transaction_pattern=DebitTransactionPatterns.DBS,
     )
 

--- a/src/monopoly/banks/hsbc/hsbc.py
+++ b/src/monopoly/banks/hsbc/hsbc.py
@@ -17,6 +17,7 @@ class Hsbc(BankBase):
     credit_config = CreditStatementConfig(
         bank_name=BankNames.HSBC,
         statement_date_pattern=r"Statement From .* to (\d{2}\s[A-Z]{3}\s\d{4})",
+        header_pattern=r"(DATE.*DESCRIPTION.*AMOUNT)",
         prev_balance_pattern=StatementBalancePatterns.HSBC,
         transaction_pattern=CreditTransactionPatterns.HSBC,
         multiline_transactions=True,

--- a/src/monopoly/banks/maybank/maybank.py
+++ b/src/monopoly/banks/maybank/maybank.py
@@ -18,6 +18,7 @@ class Maybank(BankBase):
     debit_config = DebitStatementConfig(
         bank_name=BankNames.MAYBANK,
         statement_date_pattern=r"(?:結單日期)[:\s]+(\d{2}\/\d{2}\/\d{2})",
+        header_pattern=r"(DATE.*DESCRIPTION.*AMOUNT.*BALANCE)",
         transaction_pattern=DebitTransactionPatterns.MAYBANK,
         has_withdraw_deposit_column=False,
         multiline_transactions=True,
@@ -26,6 +27,7 @@ class Maybank(BankBase):
     credit_config = CreditStatementConfig(
         bank_name=BankNames.MAYBANK,
         statement_date_pattern=r"(\d{2}\s[A-Z]{3}\s\d{2})",
+        header_pattern=r"(Date.*Description.*Amount)",
         transaction_pattern=CreditTransactionPatterns.MAYBANK,
         prev_balance_pattern=StatementBalancePatterns.MAYBANK,
         multiline_transactions=True,

--- a/src/monopoly/banks/ocbc/ocbc.py
+++ b/src/monopoly/banks/ocbc/ocbc.py
@@ -18,6 +18,7 @@ class Ocbc(BankBase):
     credit_config = CreditStatementConfig(
         bank_name=BankNames.OCBC,
         statement_date_pattern=r"(\d{2}\-\d{2}\-\d{4})",
+        header_pattern=r"(TRANSACTION DATE.*DESCRIPTION.*AMOUNT)",
         prev_balance_pattern=StatementBalancePatterns.OCBC,
         transaction_pattern=CreditTransactionPatterns.OCBC,
     )
@@ -25,7 +26,7 @@ class Ocbc(BankBase):
     debit_config = DebitStatementConfig(
         bank_name=BankNames.OCBC,
         statement_date_pattern=r"TO\s(\d+\s[A-Za-z]{3}\s\d{4})",
-        debit_statement_identifier=r"(Withdrawal.*Deposit.*Balance)",
+        header_pattern=r"(Withdrawal.*Deposit.*Balance)",
         transaction_pattern=DebitTransactionPatterns.OCBC,
         multiline_transactions=True,
     )

--- a/src/monopoly/banks/standard_chartered/standard_chartered.py
+++ b/src/monopoly/banks/standard_chartered/standard_chartered.py
@@ -17,6 +17,7 @@ class StandardChartered(BankBase):
     credit_config = CreditStatementConfig(
         bank_name=BankNames.STANDARD_CHARTERED,
         statement_date_pattern=r"(\d{2}\s\w+\s\d{4})",
+        header_pattern=r"(Transaction.*Posting.*Amount)",
         prev_balance_pattern=StatementBalancePatterns.STANDARD_CHARTERED,
         transaction_pattern=CreditTransactionPatterns.STANDARD_CHARTERED,
     )

--- a/src/monopoly/config.py
+++ b/src/monopoly/config.py
@@ -2,22 +2,10 @@ import re
 from dataclasses import field
 from typing import Any, Optional
 
-from pydantic import ConfigDict, SecretStr
+from pydantic import ConfigDict
 from pydantic.dataclasses import dataclass
-from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from monopoly.constants import BankNames, EntryType, InternalBankNames
-
-
-class PdfPasswords(BaseSettings):
-    """
-    Pydantic model that automatically populates variables from a .env file,
-    or an environment variable called `passwords`.
-    e.g. export PDF_PASSWORDS='["password123", "secretpass"]'
-    """
-
-    pdf_passwords: list[SecretStr] = [SecretStr("")]
-    model_config = SettingsConfigDict(env_file=".env", extra="allow")
 
 
 @dataclass
@@ -109,6 +97,3 @@ class PdfConfig:
 
     page_range: tuple[Optional[int], Optional[int]] = (None, None)
     page_bbox: Optional[tuple[float, float, float, float]] = None
-
-
-passwords = PdfPasswords().pdf_passwords

--- a/src/monopoly/config.py
+++ b/src/monopoly/config.py
@@ -1,4 +1,5 @@
 import re
+from dataclasses import field
 from typing import Any, Optional
 
 from pydantic import ConfigDict, SecretStr
@@ -19,7 +20,7 @@ class PdfPasswords(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="allow")
 
 
-@dataclass(frozen=True)
+@dataclass
 class DateOrder:
     """
     Supported `dateparser` DATE_ORDER arguments can be found here:
@@ -59,8 +60,8 @@ class StatementConfig:
     bank_name: BankNames | InternalBankNames
     transaction_pattern: str
     statement_date_pattern: str
-    transaction_date_order: DateOrder = DateOrder("DMY")
-    statement_date_order: DateOrder = DateOrder("DMY")
+    transaction_date_order: DateOrder = field(default_factory=lambda: DateOrder("DMY"))
+    statement_date_order: DateOrder = field(default_factory=lambda: DateOrder("DMY"))
     multiline_transactions: bool = False
     has_withdraw_deposit_column: bool = False
     header_pattern: str

--- a/src/monopoly/config.py
+++ b/src/monopoly/config.py
@@ -5,7 +5,7 @@ from pydantic import ConfigDict, SecretStr
 from pydantic.dataclasses import dataclass
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from monopoly.constants import BankNames, InternalBankNames
+from monopoly.constants import BankNames, EntryType, InternalBankNames
 
 
 class PdfPasswords(BaseSettings):
@@ -52,8 +52,8 @@ class StatementConfig:
     Defaults to DMY.
     - `multiline_transactions` controls whether Monopoly tries to concatenate
     transactions that are split across two lines
-    - `debit_statement_identifier` is a regex pattern that is used to determine whether
-    a statement from a bank is a debit or credit card statement.
+    - `header_pattern` is a regex pattern that is used to find the 'header' line
+    of a statement, and determine if it is a debit or credit card statement.
     """
 
     bank_name: BankNames | InternalBankNames
@@ -63,7 +63,7 @@ class StatementConfig:
     statement_date_order: DateOrder = DateOrder("DMY")
     multiline_transactions: bool = False
     has_withdraw_deposit_column: bool = False
-    debit_statement_identifier: Optional[str] = None
+    header_pattern: str
 
 
 @dataclass(config=ConfigDict(extra="forbid"), kw_only=True)
@@ -72,6 +72,7 @@ class DebitStatementConfig(StatementConfig):
     Dataclass storing configuration values unique to debit statements
     """
 
+    statement_type = EntryType.DEBIT
     has_withdraw_deposit_column: bool = True
 
 
@@ -84,6 +85,7 @@ class CreditStatementConfig(StatementConfig):
     line in a credit statements, which is then treated as a transaction.
     """
 
+    statement_type = EntryType.CREDIT
     prev_balance_pattern: Optional[Any | re.Pattern] = None
 
     def __post_init__(self):

--- a/src/monopoly/examples/example_bank.py
+++ b/src/monopoly/examples/example_bank.py
@@ -10,6 +10,7 @@ class ExampleBank(BankBase):
     credit_config = CreditStatementConfig(
         bank_name=InternalBankNames.EXAMPLE,
         statement_date_pattern=r"(\d{2}\-\d{2}\-\d{4})",
+        header_pattern=r"(DATE.*DESCRIPTION.*AMOUNT)",
         prev_balance_pattern=(
             r"(?P<description>LAST MONTH'S BALANCE?)\s+"
             + SharedPatterns.AMOUNT_EXTENDED_WITHOUT_EOL

--- a/src/monopoly/generic/generic_handler.py
+++ b/src/monopoly/generic/generic_handler.py
@@ -44,7 +44,7 @@ class GenericStatementHandler(StatementHandler):
                 transaction_pattern=self.transaction_pattern,
                 statement_date_pattern=self.statement_date_pattern,
                 multiline_transactions=self.multiline_transactions,
-                debit_statement_identifier=self.debit_statement_identifier,
+                header_pattern=self.header_pattern,
             )
         return None
 
@@ -58,6 +58,7 @@ class GenericStatementHandler(StatementHandler):
                 prev_balance_pattern=self.prev_balance_pattern,
                 transaction_pattern=self.transaction_pattern,
                 statement_date_pattern=self.statement_date_pattern,
+                header_pattern=self.header_pattern,
                 multiline_transactions=self.multiline_transactions,
             )
         return None
@@ -79,7 +80,7 @@ class GenericStatementHandler(StatementHandler):
         return self.analyzer.check_if_multiline()
 
     @cached_property
-    def debit_statement_identifier(self):
+    def header_pattern(self):
         return self.analyzer.get_debit_statement_header_line()
 
     @cached_property

--- a/src/monopoly/handler.py
+++ b/src/monopoly/handler.py
@@ -3,7 +3,7 @@ import re
 
 from monopoly.config import CreditStatementConfig, DebitStatementConfig, StatementConfig
 from monopoly.pdf import PdfParser
-from monopoly.statements import CreditStatement, DebitStatement
+from monopoly.statements import BaseStatement, CreditStatement, DebitStatement
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ class StatementHandler:
     def perform_safety_check(self):
         self.statement.perform_safety_check()
 
-    def get_statement(self) -> CreditStatement | DebitStatement:
+    def get_statement(self) -> BaseStatement:
         parser = self.parser
         bank = parser.bank
 

--- a/src/monopoly/pdf.py
+++ b/src/monopoly/pdf.py
@@ -15,7 +15,7 @@ from monopoly.config import passwords as env_passwords
 logger = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@dataclass
 class PdfPage:
     """
     Dataclass representation of a bank statement PDF page.

--- a/src/monopoly/pdf.py
+++ b/src/monopoly/pdf.py
@@ -8,11 +8,22 @@ from typing import Optional, Type
 import fitz
 import pdftotext
 from pydantic import SecretStr
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from monopoly.banks import BankBase
-from monopoly.config import passwords as env_passwords
 
 logger = logging.getLogger(__name__)
+
+
+class PdfPasswords(BaseSettings):
+    """
+    Pydantic model that automatically populates variables from a .env file,
+    or an environment variable called `passwords`.
+    e.g. export PDF_PASSWORDS='["password123", "secretpass"]'
+    """
+
+    pdf_passwords: list[SecretStr] = [SecretStr("")]
+    model_config = SettingsConfigDict(env_file=".env", extra="allow")
 
 
 @dataclass
@@ -65,7 +76,7 @@ class PdfDocument:
     @property
     def passwords(self):
         if not self._passwords:
-            return env_passwords
+            return PdfPasswords().pdf_passwords
         return self._passwords
 
     @cached_property

--- a/src/monopoly/pdf.py
+++ b/src/monopoly/pdf.py
@@ -15,7 +15,7 @@ from monopoly.config import passwords as env_passwords
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(frozen=True)
 class PdfPage:
     """
     Dataclass representation of a bank statement PDF page.

--- a/src/monopoly/pipeline.py
+++ b/src/monopoly/pipeline.py
@@ -13,7 +13,7 @@ from monopoly.generic import GenericStatementHandler
 from monopoly.generic.generic_handler import GenericBank
 from monopoly.handler import StatementHandler
 from monopoly.pdf import PdfDocument, PdfParser
-from monopoly.statements import CreditStatement, DebitStatement
+from monopoly.statements import BaseStatement
 from monopoly.statements.transaction import Transaction
 from monopoly.write import generate_name
 
@@ -65,7 +65,7 @@ class Pipeline:
         logger.warning("Unable to detect bank, transactions may be inaccurate")
         return GenericBank
 
-    def extract(self, safety_check=True) -> CreditStatement | DebitStatement:
+    def extract(self, safety_check=True) -> BaseStatement:
         """Extracts transactions from the statement, and performs
         a safety check to make sure that total transactions add up"""
         statement = self.handler.get_statement()
@@ -86,7 +86,7 @@ class Pipeline:
         return statement
 
     @staticmethod
-    def transform(statement: CreditStatement | DebitStatement) -> list[Transaction]:
+    def transform(statement: BaseStatement) -> list[Transaction]:
         logger.debug("Running transformation functions on DataFrame")
         transactions = statement.transactions
         statement_date = statement.statement_date
@@ -123,7 +123,7 @@ class Pipeline:
     @staticmethod
     def load(
         transactions: list[Transaction],
-        statement: CreditStatement | DebitStatement,
+        statement: BaseStatement,
         output_directory: Path,
     ):
         if isinstance(output_directory, str):

--- a/src/monopoly/statements/base.py
+++ b/src/monopoly/statements/base.py
@@ -38,6 +38,7 @@ class BaseStatement(ABC):
         self.parser = parser
         self.document = parser.document
         self.header = header
+        self.statement_type = "base"
 
     @cached_property
     def number_pattern(self) -> re.Pattern:

--- a/src/monopoly/statements/base.py
+++ b/src/monopoly/statements/base.py
@@ -27,11 +27,7 @@ class BaseStatement(ABC):
     and specific bank config.
     """
 
-    def __init__(
-        self,
-        parser: PdfParser,
-        config: StatementConfig,
-    ):
+    def __init__(self, parser: PdfParser, config: StatementConfig, header: str):
         self.pages = parser.get_pages()
         self.config = config
         self.columns: list[str] = [
@@ -41,6 +37,7 @@ class BaseStatement(ABC):
         ]
         self.parser = parser
         self.document = parser.document
+        self.header = header
 
     @cached_property
     def number_pattern(self) -> re.Pattern:

--- a/src/monopoly/write.py
+++ b/src/monopoly/write.py
@@ -2,10 +2,10 @@ from datetime import datetime
 from hashlib import sha256
 
 from monopoly.config import StatementConfig
-from monopoly.statements import CreditStatement, DebitStatement
+from monopoly.statements import BaseStatement
 
 
-def generate_hash(statement: CreditStatement | DebitStatement) -> str:
+def generate_hash(statement: BaseStatement) -> str:
     """
     Generates a hash based on PDF metadata
     """
@@ -16,7 +16,7 @@ def generate_hash(statement: CreditStatement | DebitStatement) -> str:
 
 
 def generate_name(
-    statement: CreditStatement | DebitStatement,
+    statement: BaseStatement,
     format_type: str,
     statement_config: StatementConfig,
     statement_type: str,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,7 +74,7 @@ def parser(mock_bank):
 
 
 def setup_statement_fixture(
-    statement_cls: BaseStatement | DebitStatement | CreditStatement,
+    statement_cls: BaseStatement,
     statement_config,
 ):
     mock_parser = MagicMock(spec=PdfParser)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,7 +86,7 @@ def setup_statement_fixture(
     document = MagicMock(spec=fitz.Document)
     document.name = "mock_document.pdf"
     mock_parser.document = document
-    statement = statement_cls(parser=mock_parser, config=statement_config)
+    statement = statement_cls(parser=mock_parser, config=statement_config, header="foo")
     yield statement
 
 
@@ -109,6 +109,7 @@ def statement(statement_config):
 def statement_config():
     statement_config = CreditStatementConfig(
         bank_name="example",
+        header_pattern="foo",
         transaction_pattern="foo",
         statement_date_pattern="",
         transaction_date_order=DateOrder("DMY"),

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -93,7 +93,7 @@ def test_monopoly_output(cli_runner: CliRunner):
 
         assert result.exit_code == 0
         assert "1 statement(s) processed" in result.output
-        assert "input.pdf -> example-credit-2023-07-ae15d6.csv" in result.output
+        assert "input.pdf -> example-base-2023-07-ae15d6.csv" in result.output
 
 
 def test_monopoly_no_pdf(cli_runner: CliRunner):

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from monopoly.config import PdfPasswords
+from monopoly.pdf import PdfPasswords
 
 
 @pytest.fixture


### PR DESCRIPTION
This should prevent accidental matches, where a debit config is able to find transactions in a credit statement.