### PR TITLE
refactor(pdf): decouple unlock from PdfDocument __init__

### DIFF
--- a/src/monopoly/banks/detector.py
+++ b/src/monopoly/banks/detector.py
@@ -3,7 +3,7 @@ from dataclasses import Field, fields
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Type
 
-from monopoly.identifiers import Identifier, TextIdentifier
+from monopoly.identifiers import Identifier, MetadataIdentifier, TextIdentifier
 from monopoly.pdf import PdfDocument
 
 if TYPE_CHECKING:
@@ -21,9 +21,9 @@ class BankDetector:
         """
         Retrieves encryption and metadata identifiers from a bank statement PDF
         """
-        identifiers: list[Identifier] = []
-        if metadata_identifier := self.document.metadata_identifier:
-            identifiers.append(metadata_identifier)
+        identifiers: list[MetadataIdentifier] = []
+        if identifier := self.document.metadata_identifier:
+            identifiers.append(identifier)
 
         if not identifiers:
             raise ValueError("Could not get identifier")

--- a/src/monopoly/cli.py
+++ b/src/monopoly/cli.py
@@ -131,6 +131,7 @@ def process_statement(
 
     try:
         document = PdfDocument(file)
+        document.unlock_document()
         analyzer = BankDetector(document)
         bank = analyzer.detect_bank(banks) or GenericBank
         parser = PdfParser(bank, document)

--- a/src/monopoly/pdf.py
+++ b/src/monopoly/pdf.py
@@ -86,12 +86,11 @@ class PdfDocument(Document):
         args = {"filename": self.file_path, "stream": self.file_bytes}
         super().__init__(**args)
 
-        if self.is_encrypted:
-            self._unlock_document()
+    @cached_property
+    def metadata_identifier(self):
+        return MetadataIdentifier(**self.metadata)
 
-        self.metadata_identifier = MetadataIdentifier(**self.metadata)
-
-    def _unlock_document(self):
+    def unlock_document(self):
         """Attempt to unlock the document using the provided passwords."""
         if not self.is_encrypted:
             return self

--- a/tests/integration/test_pdf_document.py
+++ b/tests/integration/test_pdf_document.py
@@ -43,7 +43,7 @@ def test_can_open_protected(pdf_document: PdfDocument):
         pdf_document = PdfDocument(
             passwords=None, file_path=fixture_directory / "protected.pdf"
         )
-        pdf_document._unlock_document()
+        pdf_document.unlock_document()
 
 
 def test_wrong_password_raises_error():
@@ -52,7 +52,7 @@ def test_wrong_password_raises_error():
             passwords=[SecretStr("wrongpw_123")],
             file_path=fixture_directory / "protected.pdf",
         )
-        pdf_document._unlock_document()
+        pdf_document.unlock_document()
 
 
 def test_override_password():
@@ -60,7 +60,7 @@ def test_override_password():
         passwords=[SecretStr("foobar123")],
         file_path=fixture_directory / "protected.pdf",
     )
-    pdf_document._unlock_document()
+    pdf_document.unlock_document()
     assert not pdf_document.is_encrypted
 
 
@@ -75,7 +75,7 @@ def test_missing_password_raises_error():
             pdf_document = PdfDocument(
                 passwords=None, file_path=fixture_directory / "protected.pdf"
             )
-            pdf_document._unlock_document()
+            pdf_document.unlock_document()
 
 
 def test_null_password_raises_error():
@@ -89,7 +89,7 @@ def test_null_password_raises_error():
             pdf_document = PdfDocument(
                 passwords=None, file_path=fixture_directory / "protected.pdf"
             )
-            pdf_document._unlock_document()
+            pdf_document.unlock_document()
 
 
 def test_invalid_password_type_raises_error():
@@ -103,7 +103,7 @@ def test_invalid_password_type_raises_error():
             pdf_document = PdfDocument(
                 passwords=None, file_path=fixture_directory / "protected.pdf"
             )
-            pdf_document._unlock_document()
+            pdf_document.unlock_document()
 
 
 def test_plain_text_passwords_raises_error(pdf_document: PdfDocument):
@@ -117,4 +117,4 @@ def test_plain_text_passwords_raises_error(pdf_document: PdfDocument):
             pdf_document = PdfDocument(
                 passwords=None, file_path=fixture_directory / "protected.pdf"
             )
-            pdf_document._unlock_document()
+            pdf_document.unlock_document()

--- a/tests/unit/test_bank_identifier/test_get_identifier.py
+++ b/tests/unit/test_bank_identifier/test_get_identifier.py
@@ -54,9 +54,7 @@ def mock_non_encrypted_document():
 
 
 def test_metadata_identifier(mock_non_encrypted_document):
-    with patch.object(
-        PdfDocument, "_unlock_document", new_callable=Mock
-    ) as mock_unlock:
+    with patch.object(PdfDocument, "unlock_document", new_callable=Mock) as mock_unlock:
         mock_unlock.return_value = mock_non_encrypted_document
 
         expected_identifier = MetadataIdentifier(


### PR DESCRIPTION
Stays true to the logic from pymupdf while adding a bit more versatility to the PdfDocument class -- instantiation (and metadata creation) will no longer fail if the document cannot be unlocked