### PR TITLE
Paylah support

### DIFF
--- a/src/monopoly/constants/statement.py
+++ b/src/monopoly/constants/statement.py
@@ -58,7 +58,7 @@ class SharedPatterns(StrEnum):
     COMMA_FORMAT = r"\d{1,3}(,\d{3})*\.\d*"
     ENCLOSED_COMMA_FORMAT = rf"\({COMMA_FORMAT}\s{{0,1}}\))"
     OPTIONAL_NEGATIVE_SYMBOL = r"(?:-)?"
-    POLARITY = r"(?P<polarity>CR\b|DR\b|\+|\-)?\s*"
+    POLARITY = r"(?P<polarity>CR\b|DR\b|DB\b|\+|\-)?\s*"
 
     AMOUNT = rf"(?P<amount>{COMMA_FORMAT}|{ENCLOSED_COMMA_FORMAT}\s*"
     AMOUNT_EXTENDED_WITHOUT_EOL = AMOUNT + POLARITY


### PR DESCRIPTION
Paylah statements use `DB` to record debit transactions instead of `DR`.
This allows the debit transactions to be recorded instead of being dropped.

Should not need any other changes since only `CR` and `+` are checked and converted to positive values: https://github.com/benjamin-awd/monopoly/blob/d5b5be6ddd88e9a4da37d3a55f8120d6560f306f/src/monopoly/statements/transaction.py#L141