### PR TITLE
Fix typo for UOB credit statement

### DIFF
--- a/src/monopoly/banks/uob/uob.py
+++ b/src/monopoly/banks/uob/uob.py
@@ -6,6 +6,7 @@ from monopoly.config import MultilineConfig, StatementConfig
 from monopoly.constants import (
     ISO8601,
     BankNames,
+    CreditTransactionPatterns,
     DebitTransactionPatterns,
     EntryType,
     StatementBalancePatterns,
@@ -23,7 +24,7 @@ class Uob(BankBase):
         statement_date_pattern=regex(rf"Statement Date.*{ISO8601.DD_MMM_YYYY}"),
         header_pattern=regex(r"(Description of Transaction.*Transaction Amount)"),
         prev_balance_pattern=StatementBalancePatterns.UOB,
-        transaction_pattern=DebitTransactionPatterns.UOB,
+        transaction_pattern=CreditTransactionPatterns.UOB,
         multiline_config=MultilineConfig(multiline_descriptions=True),
         transaction_date_format="%d %b",
     )


### PR DESCRIPTION
Hi, I believe there's a typo for the UOB credit statement config:
https://github.com/benjamin-awd/monopoly/blob/d5b5be6ddd88e9a4da37d3a55f8120d6560f306f/src/monopoly/banks/uob/uob.py#L26
it should be `transaction_pattern=CreditTransactionPatterns.UOB` instead.