### PR TITLE
feat: add Gemini parser for full statement extraction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ repository = "https://github.com/benjamin-awd/monopoly"
 ocr = [
     "ocrmypdf>=16.5.0,<17.0.0",
 ]
+gemini = [
+    "google-genai>=2.9.0",
+]
 
 [build-system]
 requires = ["pdm-backend"]
@@ -117,5 +120,8 @@ module = [
     "ocrmypdf.exceptions",
     "pdftotext",
     "pdf2john",
+    "google",
+    "google.genai",
+    "google.genai.types",
 ]
 ignore_missing_imports = true

--- a/src/monopoly/cli/cli.py
+++ b/src/monopoly/cli/cli.py
@@ -20,6 +20,76 @@ def process_statement(file: Path, config: RunConfig) -> Result | None:
     if config.verbose:
         file_context.set(file.name)
 
+    if config.parser == "gemini":
+        return _process_with_gemini(file, config)
+
+    return _process_with_pipeline(file, config)
+
+
+def _process_with_gemini(file: Path, config: RunConfig) -> Result | None:
+    """Process a statement using Google Gemini for full extraction."""
+    from monopoly.gemini import GeminiParser
+    from monopoly.pdf import PdfDocument
+
+    try:
+        document = PdfDocument(file)
+        document.unlock_document()
+
+        parser = GeminiParser()
+        result = parser.parse(document)
+
+        if config.pprint:
+            _pprint_gemini_transactions(result.transactions, file)
+            return None
+
+        if not config.output_directory:
+            config.output_directory = file.parent
+
+        output_file = _write_gemini_csv(
+            result, config.output_directory, file, preserve_filename=config.preserve_filename
+        )
+        return Result(file.name, output_file.name)
+
+    # ruff: noqa: BLE001
+    except Exception as err:
+        error_info = {
+            "message": f"{type(err).__name__}: {err!s}",
+            "traceback": traceback.format_exc(),
+        }
+        return Result(file.name, error_info=error_info)
+
+
+def _pprint_gemini_transactions(transactions: list, file: Path) -> None:
+    click.echo(f"{file.name}")
+    rows = [{"date": tx.date, "description": tx.description, "amount": str(tx.amount)} for tx in transactions]
+    headers = {col: col for col in ["date", "description", "amount"]}
+    click.echo(tabulate(rows, headers=headers, tablefmt="psql", numalign="right"))
+    click.echo()
+
+
+def _write_gemini_csv(result, output_directory: Path, file: Path, *, preserve_filename: bool) -> Path:
+    import csv
+
+    if preserve_filename:
+        filename = f"{file.stem}.csv"
+    else:
+        year = result.statement_date.year
+        month = result.statement_date.month
+        filename = f"{result.bank_name}-{year}-{month:02d}.csv"
+
+    output_path = output_directory / filename
+
+    with open(output_path, mode="w", encoding="utf8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["date", "description", "amount"])
+        for tx in result.transactions:
+            writer.writerow([tx.date, tx.description, tx.amount])
+
+    return output_path
+
+
+def _process_with_pipeline(file: Path, config: RunConfig) -> Result | None:
+    """Process a statement using the standard regex-based pipeline."""
     # Lazily importing here prevents from CLI from having a "slow" start
     from monopoly.banks import BankDetector, banks
     from monopoly.generic import GenericBank
@@ -180,6 +250,12 @@ def get_statement_paths(files: Iterable[Path]) -> set[Path]:
     is_flag=True,
     help=("Apply OCR to extract text from scanned documents."),
 )
+@click.option(
+    "--parser",
+    type=click.Choice(["gemini"], case_sensitive=False),
+    default=None,
+    help="Use an alternative parser for full statement extraction (e.g. 'gemini').",
+)
 @click.pass_context
 @setup_logs
 def monopoly(ctx: click.Context, files: list[Path], **kwargs):
@@ -237,6 +313,10 @@ def show_welcome_message():
         (
             "monopoly . --ocr",
             "applies OCR to extract text from scanned documents",
+        ),
+        (
+            "monopoly . --parser gemini",
+            "uses Google Gemini to extract transactions",
         ),
         (
             "monopoly --help",

--- a/src/monopoly/cli/models.py
+++ b/src/monopoly/cli/models.py
@@ -11,6 +11,7 @@ class RunConfig:
     safety_check: bool = True
     single_process: bool = False
     use_ocr: bool = False
+    parser: str | None = None
     verbose: bool = False
     preserve_filename: bool = False
 

--- a/src/monopoly/gemini.py
+++ b/src/monopoly/gemini.py
@@ -1,0 +1,119 @@
+import json
+import logging
+from datetime import datetime
+
+from pydantic import SecretStr
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from monopoly.pdf import PdfDocument
+from monopoly.statements.transaction import Transaction
+
+logger = logging.getLogger(__name__)
+
+EXTRACTION_PROMPT = """\
+Extract all transactions from this bank statement image.
+
+Return a JSON object with exactly this structure:
+{
+  "statement_date": "YYYY-MM-DD",
+  "bank_name": "bank name",
+  "transactions": [
+    {
+      "date": "YYYY-MM-DD",
+      "description": "merchant or description",
+      "amount": -12.34
+    }
+  ]
+}
+
+Rules:
+- statement_date: the end date of the statement period
+- bank_name: lowercase with underscores (e.g. "hsbc", "bank_of_america")
+- amount: negative for debits/purchases, positive for credits/payments/refunds
+- date: the transaction date (not the posting date)
+- Ignore non-transaction lines (headers, footers, summaries, balances, fine print)
+- Return ONLY the JSON object, no markdown fences or commentary
+"""
+
+
+class MissingApiKeyError(Exception):
+    """Raised when a required API key is not configured."""
+
+
+class GeminiSettings(BaseSettings):
+    google_api_key: SecretStr | None = None
+    model_config = SettingsConfigDict(env_file=".env", extra="allow")
+
+
+class GeminiResult:
+    def __init__(self, transactions: list[Transaction], statement_date: datetime, bank_name: str):
+        self.transactions = transactions
+        self.statement_date = statement_date
+        self.bank_name = bank_name
+
+
+class GeminiParser:
+    def __init__(self, api_key: str | None = None):
+        try:
+            from google import genai
+        except ImportError:
+            msg = "google-genai is not installed. Install it with: pip install monopoly-core[gemini]"
+            raise ImportError(msg) from None
+
+        settings = GeminiSettings()
+        key = api_key or (settings.google_api_key.get_secret_value() if settings.google_api_key else None)
+
+        if not key:
+            msg = "Google API key not found. Set GOOGLE_API_KEY environment variable or add it to your .env file."
+            raise MissingApiKeyError(msg)
+
+        self.client = genai.Client(api_key=key)
+        self.model = "gemini-2.5-flash"
+
+    def parse(self, document: PdfDocument) -> GeminiResult:
+        from google.genai import types
+
+        parts = []
+        for page in document:
+            pixmap = page.get_pixmap(dpi=300)
+            image_bytes = pixmap.tobytes("png")
+            parts.append(types.Part.from_bytes(data=image_bytes, mime_type="image/png"))
+
+        parts.append(types.Part.from_text(text=EXTRACTION_PROMPT))
+
+        logger.debug("Sending %d page(s) to Gemini for extraction", len(parts) - 1)
+
+        response = self.client.models.generate_content(
+            model=self.model,
+            contents=types.Content(parts=parts),
+        )
+
+        text = response.text or ""
+        text = text.strip()
+        if text.startswith("```"):
+            text = text.split("\n", 1)[1]
+            text = text.rsplit("```", 1)[0]
+            text = text.strip()
+
+        data = json.loads(text)
+
+        statement_date = datetime.strptime(data["statement_date"], "%Y-%m-%d").astimezone()
+        bank_name = data.get("bank_name", "unknown")
+
+        transactions = []
+        for tx in data["transactions"]:
+            transaction = Transaction(
+                transaction_date=tx["date"],
+                description=tx["description"],
+                amount=float(tx["amount"]),
+                auto_polarity=False,
+            )
+            transactions.append(transaction)
+
+        logger.debug("Gemini extracted %d transactions", len(transactions))
+
+        return GeminiResult(
+            transactions=transactions,
+            statement_date=statement_date,
+            bank_name=bank_name,
+        )

--- a/tests/unit/test_gemini_parser.py
+++ b/tests/unit/test_gemini_parser.py
@@ -1,0 +1,95 @@
+import sys
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from monopoly.gemini import GeminiParser, GeminiResult, MissingApiKeyError
+
+
+@pytest.fixture
+def mock_google_genai():
+    mock_genai = MagicMock()
+    mock_google = MagicMock()
+    mock_google.genai = mock_genai
+    with patch.dict(
+        sys.modules, {"google": mock_google, "google.genai": mock_genai, "google.genai.types": mock_genai.types}
+    ):
+        yield mock_genai
+
+
+def test_missing_google_genai_package():
+    with patch.dict(sys.modules, {"google": None, "google.genai": None}):
+        with pytest.raises(ImportError, match="google-genai is not installed"):
+            GeminiParser(api_key="test-key")
+
+
+def test_missing_api_key(mock_google_genai, monkeypatch, tmp_path):
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(MissingApiKeyError, match="Google API key not found"):
+        GeminiParser()
+
+
+def test_parse_returns_transactions(mock_google_genai):
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.text = """{
+        "statement_date": "2026-06-21",
+        "bank_name": "hsbc",
+        "transactions": [
+            {"date": "2026-05-20", "description": "COFFEE SHOP", "amount": -5.00},
+            {"date": "2026-05-21", "description": "PAYMENT - THANK YOU", "amount": 100.00}
+        ]
+    }"""
+    mock_client.models.generate_content.return_value = mock_response
+    mock_google_genai.Client.return_value = mock_client
+
+    mock_page = MagicMock()
+    mock_pixmap = MagicMock()
+    mock_pixmap.tobytes.return_value = b"fake-png-bytes"
+    mock_page.get_pixmap.return_value = mock_pixmap
+
+    mock_document = MagicMock()
+    mock_document.__iter__ = Mock(return_value=iter([mock_page]))
+
+    parser = GeminiParser(api_key="test-key")
+    result = parser.parse(mock_document)
+
+    assert isinstance(result, GeminiResult)
+    assert len(result.transactions) == 2
+    assert result.bank_name == "hsbc"
+    assert result.statement_date.year == 2026
+    assert result.statement_date.month == 6
+    assert result.transactions[0].description == "COFFEE SHOP"
+    assert result.transactions[0].amount == -5.00
+    assert result.transactions[1].amount == 100.00
+
+
+def test_parse_strips_markdown_fences(mock_google_genai):
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.text = """```json
+{
+    "statement_date": "2026-01-15",
+    "bank_name": "dbs",
+    "transactions": [
+        {"date": "2026-01-01", "description": "GROCERY", "amount": -12.34}
+    ]
+}
+```"""
+    mock_client.models.generate_content.return_value = mock_response
+    mock_google_genai.Client.return_value = mock_client
+
+    mock_page = MagicMock()
+    mock_pixmap = MagicMock()
+    mock_pixmap.tobytes.return_value = b"fake-png-bytes"
+    mock_page.get_pixmap.return_value = mock_pixmap
+
+    mock_document = MagicMock()
+    mock_document.__iter__ = Mock(return_value=iter([mock_page]))
+
+    parser = GeminiParser(api_key="test-key")
+    result = parser.parse(mock_document)
+
+    assert len(result.transactions) == 1
+    assert result.transactions[0].description == "GROCERY"


### PR DESCRIPTION
## Summary
- Adds `--parser gemini` flag that uses Google Gemini's vision API to extract structured transaction data directly from bank statement PDFs
- Bypasses the regex-based pipeline entirely — sends page images to Gemini and gets back structured JSON (date, description, amount)
- Handles complex layouts (e.g. multi-column HSBC statements) that the regex patterns cannot parse
- `google-genai` is an optional dependency (`pip install monopoly-core[gemini]`), requires `GOOGLE_API_KEY` in env

## Usage
```bash
monopoly statement.pdf --parser gemini --pprint    # preview
monopoly statement.pdf --parser gemini              # save to CSV
```

## Test plan
- [x] All 153 tests pass (99 unit + 54 integration + 4 new Gemini parser tests)
- [x] Linter, formatter, and type checker pass
- [x] Pre-commit hooks pass
- [x] Manual test with real HSBC multi-column statement — 22 transactions extracted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)