### PR TITLE
feat: add Gemini OCR engine and parser

### DIFF
--- a/src/monopoly/cli/cli.py
+++ b/src/monopoly/cli/cli.py
@@ -100,12 +100,12 @@ def _process_with_pipeline(file: Path, config: RunConfig) -> Result | None:
         document = PdfDocument(file)
         document.unlock_document()
 
-        if config.use_ocr:
+        if config.ocr_engine == "tesseract":
             document = PdfParser.apply_ocr(document)
 
         analyzer = BankDetector(document)
         bank = analyzer.detect_bank(banks) or GenericBank
-        parser = PdfParser(bank, document)
+        parser = PdfParser(bank, document, ocr_engine=config.ocr_engine)
         pipeline = Pipeline(parser)
 
         statement = pipeline.extract(safety_check=config.safety_check)
@@ -246,9 +246,12 @@ def get_statement_paths(files: Iterable[Path]) -> set[Path]:
 )
 @click.option(
     "--ocr",
-    "use_ocr",
-    is_flag=True,
-    help=("Apply OCR to extract text from scanned documents."),
+    "ocr_engine",
+    default=None,
+    is_flag=False,
+    flag_value="tesseract",
+    type=click.Choice(["tesseract", "gemini"], case_sensitive=False),
+    help="Apply OCR to extract text from scanned documents. Use 'tesseract' (default) or 'gemini'.",
 )
 @click.option(
     "--parser",
@@ -312,7 +315,11 @@ def show_welcome_message():
         ),
         (
             "monopoly . --ocr",
-            "applies OCR to extract text from scanned documents",
+            "applies OCR (tesseract) to scanned documents",
+        ),
+        (
+            "monopoly . --ocr gemini",
+            "uses Google Gemini for OCR",
         ),
         (
             "monopoly . --parser gemini",

--- a/src/monopoly/cli/models.py
+++ b/src/monopoly/cli/models.py
@@ -10,7 +10,7 @@ class RunConfig:
     pprint: bool = False
     safety_check: bool = True
     single_process: bool = False
-    use_ocr: bool = False
+    ocr_engine: str | None = None
     parser: str | None = None
     verbose: bool = False
     preserve_filename: bool = False

--- a/src/monopoly/gemini.py
+++ b/src/monopoly/gemini.py
@@ -17,6 +17,7 @@ Return a JSON object with exactly this structure:
 {
   "statement_date": "YYYY-MM-DD",
   "bank_name": "bank name",
+  "statement_type": "credit",
   "transactions": [
     {
       "date": "YYYY-MM-DD",
@@ -29,6 +30,7 @@ Return a JSON object with exactly this structure:
 Rules:
 - statement_date: the end date of the statement period
 - bank_name: lowercase with underscores (e.g. "hsbc", "bank_of_america")
+- statement_type: "credit" for credit card statements, "debit" for bank account/savings/current account statements
 - amount: negative for debits/purchases, positive for credits/payments/refunds
 - date: the transaction date (not the posting date)
 - Ignore non-transaction lines (headers, footers, summaries, balances, fine print)
@@ -46,10 +48,13 @@ class GeminiSettings(BaseSettings):
 
 
 class GeminiResult:
-    def __init__(self, transactions: list[Transaction], statement_date: datetime, bank_name: str):
+    def __init__(
+        self, transactions: list[Transaction], statement_date: datetime, bank_name: str, statement_type: str = "credit"
+    ):
         self.transactions = transactions
         self.statement_date = statement_date
         self.bank_name = bank_name
+        self.statement_type = statement_type
 
 
 class GeminiParser:
@@ -99,6 +104,7 @@ class GeminiParser:
 
         statement_date = datetime.strptime(data["statement_date"], "%Y-%m-%d").astimezone()
         bank_name = data.get("bank_name", "unknown")
+        statement_type = data.get("statement_type", "credit")
 
         transactions = []
         for tx in data["transactions"]:
@@ -116,4 +122,5 @@ class GeminiParser:
             transactions=transactions,
             statement_date=statement_date,
             bank_name=bank_name,
+            statement_type=statement_type,
         )

--- a/src/monopoly/ocr.py
+++ b/src/monopoly/ocr.py
@@ -1,0 +1,73 @@
+import logging
+
+from pydantic import SecretStr
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from monopoly.pdf import PdfDocument, PdfPage
+
+logger = logging.getLogger(__name__)
+
+EXTRACTION_PROMPT = (
+    "Extract all text from this image exactly as it appears. "
+    "Preserve the original layout, spacing, and line breaks. "
+    "Do not add any commentary, headers, or formatting. "
+    "Return only the raw text content."
+)
+
+
+class MissingApiKeyError(Exception):
+    """Raised when a required API key is not configured."""
+
+
+class GeminiSettings(BaseSettings):
+    google_api_key: SecretStr | None = None
+    model_config = SettingsConfigDict(env_file=".env", extra="allow")
+
+
+class GeminiOcr:
+    def __init__(self, api_key: str | None = None):
+        try:
+            from google import genai
+        except ImportError:
+            msg = "google-genai is not installed. Install it with: pip install monopoly-core[gemini]"
+            raise ImportError(msg) from None
+
+        settings = GeminiSettings()
+        key = api_key or (settings.google_api_key.get_secret_value() if settings.google_api_key else None)
+
+        if not key:
+            msg = "Google API key not found. Set GOOGLE_API_KEY environment variable or add it to your .env file."
+            raise MissingApiKeyError(msg)
+
+        from google import genai
+
+        self.client = genai.Client(api_key=key)
+        self.model = "gemini-2.0-flash"
+
+    def extract_pages(self, document: PdfDocument) -> list[PdfPage]:
+        from google.genai import types
+
+        pages = []
+        for page_num, page in enumerate(document):
+            logger.debug("Extracting text from page %d via Gemini", page_num + 1)
+
+            pixmap = page.get_pixmap(dpi=300)
+            image_bytes = pixmap.tobytes("png")
+
+            response = self.client.models.generate_content(
+                model=self.model,
+                contents=types.Content(
+                    parts=[
+                        types.Part.from_bytes(data=image_bytes, mime_type="image/png"),
+                        types.Part.from_text(text=EXTRACTION_PROMPT),
+                    ]
+                ),
+            )
+
+            text = response.text or ""
+            if not text.strip():
+                logger.warning("Gemini returned empty text for page %d", page_num + 1)
+
+            pages.append(PdfPage(raw_text=text))
+
+        return pages

--- a/src/monopoly/pdf.py
+++ b/src/monopoly/pdf.py
@@ -127,6 +127,7 @@ class PdfParser:
         self,
         bank: type["BankBase"],
         document: PdfDocument,
+        ocr_engine: str | None = None,
     ):
         """
         Class responsible for parsing PDFs and returning raw text.
@@ -137,6 +138,7 @@ class PdfParser:
         self.bank = bank
         self.document = document
         self.metadata_identifier = document.metadata_identifier
+        self.ocr_engine = ocr_engine
 
     @property
     def pdf_config(self):
@@ -165,6 +167,14 @@ class PdfParser:
     def _get_pages(self) -> list[PdfPage]:
         logger.debug("Extracting text from PDF")
         document = self.document
+
+        if self.ocr_engine == "gemini":
+            from monopoly.ocr import GeminiOcr
+
+            gemini = GeminiOcr()
+            pages = gemini.extract_pages(document)
+            num_pages = list(range(len(pages)))
+            return [pages[i] for i in num_pages[self.page_range]]
 
         num_pages = list(range(document.page_count))
         document.select(num_pages[self.page_range])

--- a/tests/unit/test_gemini_ocr.py
+++ b/tests/unit/test_gemini_ocr.py
@@ -1,0 +1,88 @@
+import sys
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+from monopoly.ocr import MissingApiKeyError
+from monopoly.pdf import PdfPage
+
+
+@pytest.fixture
+def mock_google_genai():
+    """Mock the google.genai module since it's an optional dependency."""
+    mock_genai = MagicMock()
+    mock_google = MagicMock()
+    mock_google.genai = mock_genai
+    with patch.dict(
+        sys.modules, {"google": mock_google, "google.genai": mock_genai, "google.genai.types": mock_genai.types}
+    ):
+        yield mock_genai
+
+
+def test_missing_google_genai_package():
+    with patch.dict(sys.modules, {"google": None, "google.genai": None}):
+        from monopoly.ocr import GeminiOcr
+
+        with pytest.raises(ImportError, match="google-genai is not installed"):
+            GeminiOcr(api_key="test-key")
+
+
+def test_missing_api_key(mock_google_genai, monkeypatch):
+    from monopoly.ocr import GeminiOcr
+
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    with patch("monopoly.ocr.GeminiSettings") as mock_settings_cls:
+        mock_settings_cls.return_value.google_api_key = None
+        with pytest.raises(MissingApiKeyError, match="Google API key not found"):
+            GeminiOcr()
+
+
+def test_extract_pages(mock_google_genai):
+    from monopoly.ocr import GeminiOcr
+
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.text = "01 JAN  COFFEE SHOP  5.00\n02 JAN  GROCERY STORE  25.00"
+    mock_client.models.generate_content.return_value = mock_response
+    mock_google_genai.Client.return_value = mock_client
+
+    mock_page = MagicMock()
+    mock_pixmap = MagicMock()
+    mock_pixmap.tobytes.return_value = b"fake-png-bytes"
+    mock_page.get_pixmap.return_value = mock_pixmap
+
+    mock_document = MagicMock()
+    mock_document.__iter__ = Mock(return_value=iter([mock_page]))
+
+    ocr = GeminiOcr(api_key="test-key")
+    pages = ocr.extract_pages(mock_document)
+
+    assert len(pages) == 1
+    assert isinstance(pages[0], PdfPage)
+    assert "COFFEE SHOP" in pages[0].raw_text
+    assert "GROCERY STORE" in pages[0].raw_text
+    mock_page.get_pixmap.assert_called_once_with(dpi=300)
+
+
+def test_extract_pages_empty_response(mock_google_genai):
+    from monopoly.ocr import GeminiOcr
+
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.text = ""
+    mock_client.models.generate_content.return_value = mock_response
+    mock_google_genai.Client.return_value = mock_client
+
+    mock_page = MagicMock()
+    mock_pixmap = MagicMock()
+    mock_pixmap.tobytes.return_value = b"fake-png-bytes"
+    mock_page.get_pixmap.return_value = mock_pixmap
+
+    mock_document = MagicMock()
+    mock_document.__iter__ = Mock(return_value=iter([mock_page]))
+
+    ocr = GeminiOcr(api_key="test-key")
+    pages = ocr.extract_pages(mock_document)
+
+    assert len(pages) == 1
+    assert pages[0].raw_text == ""


### PR DESCRIPTION
## Summary
- Add Google Gemini as an alternative OCR engine via `--ocr gemini` CLI flag
- Add Gemini-based full statement parser via `--parser gemini` for direct transaction extraction
- Extract `statement_type` (credit/debit) from Gemini-parsed bank statements
- Fix missing `parser` field in `RunConfig` that broke CLI tests
- Fix `test_missing_api_key` to patch `GeminiSettings` so it doesn't read from local `.env`

## Test plan
- [x] All 157 tests pass locally (including pre-commit hooks)
- [x] `test_gemini_ocr.py` — 4 tests covering missing package, missing API key, page extraction, and empty responses
- [x] `test_gemini_parser.py` — 4 tests covering parsing, missing package, missing API key, and malformed responses
- [x] `test_cli.py` — 10 tests pass (previously 4 were failing due to missing `parser` field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)