### PR TITLE
fix(gemini): include previous statement balance as a transaction

### DIFF
--- a/src/monopoly/gemini.py
+++ b/src/monopoly/gemini.py
@@ -33,7 +33,9 @@ Rules:
 - statement_type: "credit" for credit card statements, "debit" for bank account/savings/current account statements
 - amount: negative for debits/purchases, positive for credits/payments/refunds
 - date: the transaction date (not the posting date)
-- Ignore non-transaction lines (headers, footers, summaries, balances, fine print)
+- Include "Previous Statement Balance" or similar balance carry-forward lines as transactions \
+(use the statement start date as the date). These are needed for totals to balance.
+- Ignore other non-transaction lines (headers, footers, summaries, fine print)
 - Return ONLY the JSON object, no markdown fences or commentary
 """
 


### PR DESCRIPTION
## Summary
- Updated Gemini extraction prompt to include "Previous Statement Balance" (and similar carry-forward lines) as transactions instead of ignoring them
- Without this, credit card statement totals don't balance — e.g. HSBC statements show the previous balance as a line item in the transaction list, and omitting it causes the net total to be off

## Test plan
- [x] Ran Gemini parser against HSBC credit card statement
- [x] Existing unit tests pass
- [x] Pre-commit hooks pass (ruff, pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)