### PR TITLE
fix(uob): support current/savings account (debit) statements

### DIFF
--- a/src/monopoly/banks/uob/uob.py
+++ b/src/monopoly/banks/uob/uob.py
@@ -33,7 +33,9 @@ class Uob(BankBase):
             rf"(?P<transaction_date>{ISO8601.DD_MMM})\s+"
             + SharedPatterns.DESCRIPTION
             + SharedPatterns.AMOUNT_EXTENDED_WITHOUT_EOL
-            + SharedPatterns.BALANCE
+            # a running balance is always present, so require it to avoid matching
+            # single-number lines like "BALANCE B/F" or summary-page amounts
+            + rf"(?P<balance>{SharedPatterns.COMMA_FORMAT})$"
         ),
         transaction_bound=170,
         multiline_config=MultilineConfig(multiline_descriptions=True),
@@ -43,11 +45,11 @@ class Uob(BankBase):
     identifiers = [
         [
             MetadataIdentifier(
-                format="PDF 1.5",
                 creator="Vault Rendering Engine",
                 producer="Rendering Engine",
             ),
         ],
         [TextIdentifier("card.centre@uobgroup.com")],
+        [TextIdentifier("customer.service@uobgroup.com")],
     ]
     statement_configs = [credit, debit]

--- a/tests/integration/banks/test_uob_transaction_pattern.py
+++ b/tests/integration/banks/test_uob_transaction_pattern.py
@@ -1,0 +1,35 @@
+"""Regression tests for the UOB debit statement transaction pattern.
+
+UOB current/savings account statements print a running balance next to every
+transaction, but also contain single-number lines (e.g. "BALANCE B/F" and
+summary-page amounts) that must not be picked up as transactions.
+"""
+
+from monopoly.banks import Uob
+
+pattern = Uob.debit.transaction_pattern
+
+
+def test_matches_withdrawal_with_running_balance():
+    match = pattern.search("04 Jun             Debit Card Payment                29.55                     8,731.74")
+    assert match is not None
+    assert match.group("transaction_date") == "04 Jun"
+    assert match.group("amount") == "29.55"
+    assert match.group("balance") == "8,731.74"
+
+
+def test_matches_deposit_with_running_balance():
+    match = pattern.search("22 Jun             Funds Transfer                                 200.00         6,827.49")
+    assert match is not None
+    assert match.group("amount") == "200.00"
+    assert match.group("balance") == "6,827.49"
+
+
+def test_ignores_balance_brought_forward():
+    # "BALANCE B/F" only carries a balance, with no amount + running balance pair
+    assert pattern.search("01 Jun             BALANCE B/F                                        8,761.29") is None
+
+
+def test_ignores_summary_page_amount():
+    # a date appearing mid-line on the summary page, with a single trailing number
+    assert pattern.search("Locked Amount as of 30 Jun 2026 is 0.00") is None

--- a/tests/unit/test_bank_identifier/test_uob_identifiers.py
+++ b/tests/unit/test_bank_identifier/test_uob_identifiers.py
@@ -1,0 +1,27 @@
+"""Detection tests for UOB, which renders account and card statements differently."""
+
+from unittest.mock import PropertyMock, patch
+
+from monopoly.banks import Uob
+from monopoly.banks.detector import BankDetector
+from monopoly.identifiers import MetadataIdentifier
+from monopoly.pdf import PdfDocument
+
+
+def test_uob_detected_regardless_of_pdf_version(metadata_analyzer: BankDetector):
+    # Account (debit) statements are rendered as PDF 1.4, credit card
+    # statements as PDF 1.5 - detection must not depend on the version.
+    metadata_analyzer.metadata_identifier = MetadataIdentifier(
+        format="PDF 1.4",
+        creator="Vault Rendering Engine",
+        producer="Rendering Engine 7.4.1.9",
+    )
+    assert metadata_analyzer.detect_bank([Uob]) is Uob
+
+
+@patch.object(PdfDocument, "raw_text", new_callable=PropertyMock)
+def test_uob_detected_via_customer_service_text(mock_raw_text, metadata_analyzer: BankDetector):
+    # Fall back to the account-statement contact email when metadata differs.
+    mock_raw_text.return_value = "Email customer.service@uobgroup.com"
+    metadata_analyzer.metadata_identifier = MetadataIdentifier(creator="unknown", producer="unknown")
+    assert metadata_analyzer.detect_bank([Uob]) is Uob


### PR DESCRIPTION
## Problem

UOB current/savings account (debit) statements were never processed. Bank detection failed, the statement fell through to the `GenericBank` parser, and extraction crashed with:

```
RuntimeError: Could not find header in statement
```

Two independent issues were involved.

### 1. Detection — over-pinned PDF version

The UOB metadata identifier required `format="PDF 1.5"`, but **account statements are rendered as PDF 1.4** (only credit card statements are 1.5). Since `MetadataIdentifier` requires every configured field to match, the version mismatch alone caused detection to fail. The `card.centre@uobgroup.com` text fallback only appears on card statements, so account statements matched nothing.

Observed metadata:

| field | old config | account statement |
|-------|-----------|-------------------|
| format | `PDF 1.5` | `PDF 1.4` ❌ |
| creator | `Vault Rendering Engine` | ✅ |
| producer | `Rendering Engine` | `Rendering Engine 7.4.1.9` ✅ |

**Fix:** drop the `format` constraint (creator + producer are already UOB-specific) and add `customer.service@uobgroup.com` as a text-identifier fallback for account statements.

### 2. Parsing — optional running balance

The debit transaction pattern ended with the shared `BALANCE` group, which is optional. Single-number lines such as `BALANCE B/F` and a summary-page amount (`Locked Amount as of 30 Jun 2026 is 0.00`) were therefore matched as transactions, inflating the deposit total and failing the safety check.

**Fix:** require a running balance — every genuine UOB debit transaction line carries one.

## Testing

- Verified end-to-end against a real UOB account statement (not committed — contains PII): bank detected as `uob`, 9 transactions extracted with continuous balances, deposit (200.32) and withdrawal (2,222.20) totals match the document, safety check passes.
- Added `tests/unit/test_bank_identifier/test_uob_identifiers.py` — detection works for PDF 1.4 metadata and via the contact-email fallback.
- Added `tests/integration/banks/test_uob_transaction_pattern.py` — genuine transactions match; `BALANCE B/F` and summary lines do not.
- Full suite: `163 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)