### PR TITLE
fix(trust): match stacked/wrapped transaction header

### DIFF
--- a/src/monopoly/banks/trust/trust.py
+++ b/src/monopoly/banks/trust/trust.py
@@ -19,7 +19,10 @@ class Trust(BankBase):
             r".*?"
             r"(?P<year>20\d{2}\b)"
         ),
-        header_pattern=re.compile(r"(Posting date.*Description.*Amount in SGD)"),
+        header_pattern=re.compile(
+            r"(Posting date.*Description.*Amount in SGD"
+            r"|Transaction\s+Posting.*Amount in\s+Amount in)"
+        ),
         transaction_pattern=re.compile(
             rf"(?P<transaction_date>{ISO8601.DD_MMM})\s+"
             rf"(?:{ISO8601.DD_MMM}\s+)?"  # Optional posting date

--- a/tests/integration/banks/test_trust_transaction_pattern.py
+++ b/tests/integration/banks/test_trust_transaction_pattern.py
@@ -153,3 +153,25 @@ def test_trust_transaction_with_decimal_fcy(statement: BaseStatement):
         )
     ]
     assert transactions == expected
+
+
+def test_trust_header_pattern_single_line_layout():
+    """The original (single date column) header renders on one line.
+
+    Example: Posting date   Description   Amount in FCY   Amount in SGD
+    """
+    header = "Posting date   Description   Amount in FCY   Amount in SGD"
+    assert Trust.credit.header_pattern.search(header)
+
+
+def test_trust_header_pattern_stacked_layout():
+    """Newer statements add a Transaction date column, wrapping the header
+    across multiple lines. The pattern must still match the top line.
+
+    Example layout:
+        Transaction   Posting                     Amount in     Amount in
+                                Description
+        date          date                              FCY          SGD
+    """
+    header = "Transaction   Posting                     Amount in     Amount in"
+    assert Trust.credit.header_pattern.search(header)


### PR DESCRIPTION
## Problem

Trust credit card statements stopped parsing, failing with:

```
RuntimeError: Could not find header in statement
```

The bank is still detected correctly, but header detection fails and the entire statement is rejected.

## Root cause

Trust added a **Transaction date** column to the statement, which reflowed the transaction table header from a single line into a stacked, multi-line block:

**Before (single line):**
```
Posting date   Description   Amount in FCY   Amount in SGD
```

**Now (stacked across 3 lines):**
```
Transaction   Posting                     Amount in     Amount in
                        Description
date          date                              FCY          SGD
```

`get_header()` matches per line, so the old single-line pattern
`Posting date.*Description.*Amount in SGD` matches nothing → `RuntimeError`.

## Fix

Broaden `Trust.credit.header_pattern` to also match the top line of the
stacked layout, while still matching the original single-line format.

Row parsing is unchanged: the existing transaction pattern already handles
the two-date / description-on-previous-line structure (the row layout itself
did not change, only the header wrapped).

## Validation

- Reproduced against a real affected statement: **33 transactions** extracted,
  correct statement date, and the balance safety-check reconciles.
- Added regression tests covering both the single-line and stacked header layouts.
- Existing Trust suite (including the full 2024 fixture parse) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
