### PR TITLE
ci(release-please): bump action to v5

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Run release-please
         id: release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Bumps `googleapis/release-please-action` from v4 to **v5.0.0**.

The only breaking change in v5 is the upgrade to the Node 24 runtime — this clears the Node 20 deprecation warning surfaced on the last release-please run. Inputs (`config-file`, `manifest-file`) and outputs (`release_created`, `tag_name`) are unchanged, so no config changes are required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)