### PR TITLE
chore(dependabot): group github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Add a `deps` group (matching `*`) to the `github-actions` package ecosystem in `.github/dependabot.yml`, so GitHub Actions bumps are batched into a single PR like the existing `pip` config.

## Why
The `pip` ecosystem already groups all dependency updates into one PR. This applies the same grouping to `github-actions` to reduce PR noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)