### PR TITLE
ci: update uv.lock via release-please extra-files instead of a custom job

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -15,8 +15,6 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
-      prs_created: ${{ steps.release.outputs.prs_created }}
-      pr: ${{ steps.release.outputs.pr }}
     steps:
       - name: Run release-please
         id: release
@@ -24,39 +22,6 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-  # release-please bumps the version in pyproject.toml but knows nothing about
-  # uv.lock, which pins monopoly-core itself. Re-lock on the release PR branch
-  # so the lockfile lands in the same commit range as the bump.
-  relock:
-    needs: release-please
-    if: needs.release-please.outputs.prs_created == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout release PR branch
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ fromJson(needs.release-please.outputs.pr).headBranchName }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Re-lock
-        run: uv lock
-
-      - name: Commit uv.lock if it changed
-        run: |
-          if git diff --quiet -- uv.lock; then
-            echo "uv.lock already in sync"
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add uv.lock
-          git commit -m "chore: sync uv.lock with released version"
-          git push
 
   publish:
     needs: release-please

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,14 @@
       "include-component-in-tag": false,
       "include-v-in-tag": true,
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "uv.lock",
+          "jsonpath": "$.package[?(@.name.value=='monopoly-core')].version"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Follow-up to #298. That PR added a `relock` job to work around release-please
not updating `uv.lock`. **The job is unnecessary** — release-please can do it
declaratively, so this removes the job (-35 lines) and replaces it with an
`extra-files` entry.

```json
"extra-files": [
  {
    "type": "toml",
    "path": "uv.lock",
    "jsonpath": "$.package[?(@.name.value=='monopoly-core')].version"
  }
]
```

The bump now lands in the release PR's own commit, instead of a follow-up bot
push that doesn't retrigger workflows.

## Why the jsonpath looks wrong

It reads `@.name.value` on the filter but plain `.version` on the target, which
looks like a typo and isn't. release-please parses TOML into annotated
`{start, end, value}` nodes, so the filter has to go through `.value` — but its
*write* path uses plain JSON, so the target must not. I tested all three
variants against release-please **17.11.2**, which is what
`release-please-action@v5` depends on (`^17.6.0`):

| jsonpath | result |
|---|---|
| `@.name.value=='monopoly-core'` → `.version` | ✅ `0.21.7` → `0.22.0`, **exactly one line changed** |
| `@.name.value=='monopoly-core'` → `.version.value` | ❌ throws `path not found in object: package.32.version.value` |
| `@.name=="monopoly-core"` → `.version` | ⚠️ **silently modifies nothing** — warns `No entries modified`, exits 0 |

Re-verified against the current `uv.lock` after the dependabot bumps on `main`,
not just the version I first tested.

That third row is the trap from googleapis/release-please#2455, and it's the
dangerous one: it doesn't fail, so a release would quietly ship a stale
lockfile. **This is why the `uv sync --locked` guard from #298 matters** — if
the upstream `toml-edit` bug is ever fixed and this path stops matching, CI
fails on the release PR instead of the drift reaching `main`. The two changes
cover each other.

## Context

release-please supports npm lockfiles (`src/updaters/node/package-lock-json.ts`)
but no Python lockfile updater — `src/updaters/python/` has only `setup-py`,
`setup-cfg`, `pyproject-toml` and `python-file-with-version`. Native `uv.lock`
support is proposed in googleapis/release-please#2693 (open since Mar 2026,
closes #2561), which would let this entry be dropped entirely.

## Verification

- `ruff format --check .` — 122 files already formatted
- `ruff check .` — all checks passed
- `mypy src` — no issues, 77 source files
- `pytest . -n auto` — **172 passed, 0 skipped**, git-crypt fixtures unlocked
- `uv sync --all-extras --locked` — ok
- `release-please.yaml` and `release-please-config.json` both parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)
