### PR TITLE
fix(dbs): raise consolidated transaction_bound to 230

### DIFF
--- a/src/monopoly/banks/dbs/dbs.py
+++ b/src/monopoly/banks/dbs/dbs.py
@@ -69,7 +69,12 @@ class Dbs(BankBase):
             + SharedPatterns.DESCRIPTION
             + SharedPatterns.AMOUNT_EXTENDED_WITHOUT_EOL
         ),
-        transaction_bound=220,
+        # Later pages of a consolidated statement indent the table further right
+        # than the first page (Balance column drifts 210 -> 223 -> 234), pushing
+        # the withdrawal/deposit amount column to col 223 on some pages. 230 keeps
+        # those real amounts while still rejecting balance-only summary lines,
+        # whose amounts land at col 239+.
+        transaction_bound=230,
     )
 
     identifiers = [


### PR DESCRIPTION
## What

Raise the `transaction_bound` on the DBS `consolidated` `StatementConfig` from
220 to 230.

## Why

A 2026 DBS/POSB consolidated statement failed to parse with
`SafetyCheckError` — the extracted transactions were short by exactly 0.08.

Root cause: later pages of a consolidated statement indent the transaction
table further right than the first page. The Balance column drifts across
pages (observed 210 → 223 → 234), which pushes the withdrawal/deposit amount
column to character 223 on a later page. With `transaction_bound=220`, the
`31 Aug  Interest Earned  0.08` deposit on that page was rejected as
"beyond boundary" and dropped, so the transactions no longer reconciled.

230 keeps the real withdrawal/deposit amounts (max observed column 223) while
still rejecting balance-only summary lines, whose amounts land at column 239+.

## Verification

- `uv run monopoly <statement>.pdf --pprint` now extracts all 10 transactions
  (including `Interest Earned`) and the safety check passes.
- Full gate green: `ruff format`/`ruff check`/`mypy` clean;
  `172 passed, 0 skipped` with git-crypt fixtures **unlocked**, so the DBS
  credit + debit integration tests actually ran.

## Notes / follow-up

This remains an absolute character bound, so a future statement vintage with
even more indentation could require another bump. The `consolidated` config
still has no integration fixtures (this fix could not add one — the sample is
a real personal statement), so it stays uncovered against future column drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)