### PR TITLE
fix(standard_chartered): detect OpenPDF-generated statements

### DIFF
--- a/src/monopoly/banks/standard_chartered/standard_chartered.py
+++ b/src/monopoly/banks/standard_chartered/standard_chartered.py
@@ -40,7 +40,15 @@ class StandardChartered(BankBase):
                 producer="iText",
             ),
             TextIdentifier("Standard Chartered"),
-        ]
+        ],
+        [
+            # 2026 onwards: SC switched its PDF generator from iText to OpenPDF
+            MetadataIdentifier(
+                title="eStatement",
+                producer="OpenPDF",
+            ),
+            TextIdentifier("Standard Chartered"),
+        ],
     ]
 
     statement_configs = [credit]


### PR DESCRIPTION
## Problem

Standard Chartered credit statements from 2026 are detected as generic
instead of matching the `StandardChartered` bank config.

The single identifier group requires `MetadataIdentifier(producer="iText")`,
but SC switched its PDF generator from iText to OpenPDF. New statements
report `producer="OpenPDF 2.0.2"`, so the metadata identifier fails →
the whole group fails → `detect_bank` returns `None` → generic fallback.
The `TextIdentifier("Standard Chartered")` still matches; producer was the
only blocker.

## Fix

Add a second identifier group for the OpenPDF producer rather than
loosening the existing one (per the CLAUDE.md convention). Uses the bare
`"OpenPDF"` substring so it survives minor version bumps, matching how the
existing group uses `"iText"`.

## Verification

- Detection now returns `StandardChartered` for the 2026 sample PDF
- `extract()` (safety check on) + `transform()` succeed on the sample
- `pytest tests/integration/banks/test_banks_credit.py` — 7 passed
- `ruff check` and `mypy` clean

Note: no regression fixture added — real SC statements are PII/gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)