### PR TITLE
fix(serialize): give duplicate transactions distinct JSON ids

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,7 @@ The CLI (`src/monopoly/cli/cli.py`) supports:
 - Output format with `--format csv|json` (`-f`). CSV stays a fixed 4-column
   contract; JSON emits the versioned richer schema built by
   `src/monopoly/serialize.py` (`SCHEMA_VERSION`, statement metadata, payment
-  summary, and a stable per-transaction `id`). Bump `SCHEMA_VERSION` on any
+  summary, and a unique per-transaction `id`). Bump `SCHEMA_VERSION` on any
   breaking envelope change.
 - Pretty-print mode with `--pprint` (no CSV output)
 - OCR support with `--ocr` flag
@@ -195,6 +195,20 @@ raw `polarity` marker), and a nullable `account` slot. `Transaction.direction` i
 normalized in the model; the internal parser still captures raw markers into
 `RawTransaction.direction`. Known follow-ups (currently `None`): per-transaction
 original/FX currency + amount, account last-4, and `period_start`.
+
+Per-transaction `id`: the JSON `"id"` is *unique within an envelope* and is the
+only sanctioned per-row identifier, produced by `serialize.assign_ids`. It is a
+transaction's `Transaction.content_hash` for the first occurrence of a given
+fingerprint and a re-hash of `(content_hash, n)` for the nth duplicate — so two
+genuinely-distinct transactions with identical fields (e.g. two identical
+same-day transfers) still get distinct ids. `content_hash` itself is a *content
+fingerprint that deliberately collides* for identical content; never use it
+directly as a per-row id (that reintroduces collisions). Two caveats: (1) the
+occurrence ordinal is stable within one statement's row order but cannot
+guarantee cross-statement stability if a bank re-sorts identical same-day rows
+in an overlapping statement — inherent to a stateless parser; (2) populating the
+`account` follow-up (issue #308) folds a new field into `content_hash` and will
+rotate *every* `id`, not just duplicates.
 
 ## Important Implementation Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,6 @@ improvising a workflow:
 | `/verify` | Run the full gate and report what passed, failed, or **skipped** |
 | `/add-bank` | Add a bank or statement type from a sample PDF |
 | `/debug-statement` | Diagnose a single PDF that fails to parse |
-| `/commit` | Conventional Commits, as release-please and git-cliff expect |
 
 `dev-guide` (auto-loaded) is the reference for test/lint/type commands.
 The `statement-debugger` subagent investigates a failing PDF without pulling

--- a/src/monopoly/serialize.py
+++ b/src/monopoly/serialize.py
@@ -7,8 +7,10 @@ objects — so the returned dict can be handed straight to `json.dump` without a
 custom encoder, and asserted directly in tests.
 """
 
+from collections import Counter
 from dataclasses import asdict
 from datetime import date, datetime
+from hashlib import sha256
 from typing import Any
 
 from monopoly.statements import BaseStatement, Transaction
@@ -36,9 +38,41 @@ def _payment_summary_to_dict(statement: BaseStatement) -> dict[str, Any] | None:
     return summary
 
 
-def _transaction_to_dict(transaction: Transaction) -> dict[str, Any]:
+def assign_ids(transactions: list[Transaction]) -> list[str]:
+    """
+    Return a unique per-row `id` for each transaction, in list order.
+
+    This is the ONLY sanctioned source of the JSON `"id"`. The id is the
+    transaction's `content_hash` for the first occurrence of a given fingerprint,
+    and `sha256(repr((content_hash, n)))` for the nth (n>0) occurrence within this
+    list. That disambiguates genuinely-distinct transactions sharing identical
+    content (e.g. two identical same-day transfers) while leaving every
+    non-duplicated id byte-identical to its bare `content_hash`.
+
+    The ordinal is assigned in list order, so callers must pass transactions in a
+    stable order (statement extraction order). The ordinal is stable within a
+    statement but cannot guarantee cross-statement stability if a bank re-sorts
+    identical same-day rows — inherent to a stateless parser (see docs).
+
+    Do not use `Transaction.content_hash` directly as a per-row id; it collides
+    for identical content. Always route through this function.
+    """
+    seen: Counter[str] = Counter()
+    ids: list[str] = []
+    for transaction in transactions:
+        base = transaction.content_hash
+        occurrence = seen[base]
+        seen[base] += 1
+        if occurrence == 0:
+            ids.append(base)
+        else:
+            ids.append(sha256(repr((base, occurrence)).encode("utf-8")).hexdigest())
+    return ids
+
+
+def _transaction_to_dict(transaction: Transaction, tx_id: str) -> dict[str, Any]:
     return {
-        "id": transaction.transaction_id,
+        "id": tx_id,
         "transaction_date": transaction.date,
         "posting_date": transaction.posting_date,
         "description": transaction.description,
@@ -64,5 +98,7 @@ def statement_to_dict(statement: BaseStatement, transactions: list[Transaction])
         "period_start": None,
         "period_end": _iso(statement.statement_date),
         "payment_summary": _payment_summary_to_dict(statement),
-        "transactions": [_transaction_to_dict(tx) for tx in transactions],
+        "transactions": [
+            _transaction_to_dict(tx, tx_id) for tx, tx_id in zip(transactions, assign_ids(transactions), strict=True)
+        ],
     }

--- a/src/monopoly/statements/transaction.py
+++ b/src/monopoly/statements/transaction.py
@@ -163,15 +163,25 @@ class Transaction:
         return json.dumps(self.as_raw_dict(show_direction=True))
 
     @property
-    def transaction_id(self) -> str:
+    def content_hash(self) -> str:
         """
-        Stable content hash identifying this transaction across statements.
+        Content fingerprint of this transaction — NOT a unique per-row id.
 
         Hashes the transaction's *identity* — date, description, amount, currency,
         and account — deliberately excluding the running `balance`, which is
-        statement-position-dependent. This is separate from `write.generate_hash`
-        (the per-statement filename UUID) and is kept out of `__str__`/`as_raw_dict`
-        so the filename hash stays byte-stable.
+        statement-position-dependent. Because it is a pure content hash, two
+        genuinely-distinct transactions with identical fields (e.g. two identical
+        same-day transfers) produce the *same* fingerprint. This is intentional:
+        the fingerprint is a dedup/identity signal, not a primary key.
+
+        The unique per-row `id` emitted in the JSON schema is derived from this
+        fingerprint plus an occurrence ordinal by `serialize.assign_ids`; that is
+        the only sanctioned source of unique ids. Do not use `content_hash`
+        directly as a per-transaction id — that reintroduces collisions.
+
+        This is separate from `write.generate_hash` (the per-statement filename
+        UUID) and is kept out of `__str__`/`as_raw_dict` so the filename hash
+        stays byte-stable.
 
         Computed fresh on each access (not cached) so it can't freeze a stale
         value if read before the pipeline stamps currency or normalizes the date.

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -1,7 +1,8 @@
 import json
+import re
 from datetime import datetime
 
-from monopoly.serialize import SCHEMA_VERSION, statement_to_dict
+from monopoly.serialize import SCHEMA_VERSION, assign_ids, statement_to_dict
 from monopoly.statements import Transaction
 
 TRANSACTION_KEYS = {
@@ -78,3 +79,67 @@ def test_balance_null_when_absent_float_when_present(credit_statement):
     envelope = statement_to_dict(credit_statement, transactions)
     assert envelope["transactions"][0]["balance"] is None
     assert envelope["transactions"][1]["balance"] == 100.0
+
+
+def _dup(**overrides):
+    """A transaction whose identity fields collide by default (a real duplicate)."""
+    base = {"transaction_date": "2023-06-01", "description": "SHOPEE", "amount": "100.00", "currency": "SGD"}
+    base.update(overrides)
+    return Transaction(**base)
+
+
+def test_assign_ids_disambiguates_two_identical_rows():
+    txs = [_dup(), _dup()]
+    # sanity: the two rows genuinely collide at the content-hash level
+    assert txs[0].content_hash == txs[1].content_hash
+    ids = assign_ids(txs)
+    assert len(set(ids)) == 2
+    # first occurrence keeps the bare content hash (byte stability)
+    assert ids[0] == txs[0].content_hash
+    assert ids[1] != txs[1].content_hash
+
+
+def test_assign_ids_disambiguates_three_identical_rows():
+    txs = [_dup(), _dup(), _dup()]
+    ids = assign_ids(txs)
+    # guards off-by-one / non-monotonic ordinal
+    assert len(set(ids)) == 3
+    assert ids[0] == txs[0].content_hash
+
+
+def test_assign_ids_leaves_unique_rows_as_content_hash():
+    a = _dup(description="A")
+    b = _dup(description="B")
+    assert assign_ids([a, b]) == [a.content_hash, b.content_hash]
+
+
+def test_assign_ids_is_deterministic():
+    txs = [_dup(), _dup(), _dup(description="OTHER")]
+    assert assign_ids(txs) == assign_ids(txs)
+
+
+def test_envelope_gives_duplicate_rows_distinct_ids(credit_statement):
+    credit_statement.statement_date = datetime(2023, 6, 30)
+    envelope = statement_to_dict(credit_statement, [_dup(), _dup()])
+    ids = [tx["id"] for tx in envelope["transactions"]]
+    assert len(set(ids)) == 2
+
+
+def test_credit_prev_balance_prepend_preserves_duplicate_ordinals(credit_statement, monkeypatch):
+    """`post_process_transactions` prepends a synthetic prev-balance row via
+    insert(0, ...). Ensure the reorder doesn't break ordinal assignment for a
+    real duplicate pair, and the synthetic row isn't content-identical to them."""
+    match = re.compile(r"(?P<description>PREV BAL) (?P<amount>[\d.]+)").search("PREV BAL 500.00")
+    monkeypatch.setattr(credit_statement, "get_prev_month_balances", lambda: [match])
+
+    processed = credit_statement.post_process_transactions([_dup(), _dup()])
+
+    # synthetic row prepended
+    assert len(processed) == 3
+    # not content-identical to the real duplicates (would otherwise steal an ordinal)
+    assert processed[0].content_hash != processed[1].content_hash
+
+    ids = assign_ids(processed)
+    assert len(set(ids)) == 3
+    # the real duplicate pair (now at indices 1, 2) is still disambiguated
+    assert ids[1] != ids[2]

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -56,30 +56,30 @@ def _tx(**overrides):
     return Transaction(**base)
 
 
-def test_transaction_id_stable_across_identical_transactions():
-    assert _tx().transaction_id == _tx().transaction_id
+def test_content_hash_stable_across_identical_transactions():
+    assert _tx().content_hash == _tx().content_hash
     # balance is excluded from identity: same id despite differing running balance
-    assert _tx(balance="100.00").transaction_id == _tx(balance="999.00").transaction_id
+    assert _tx(balance="100.00").content_hash == _tx(balance="999.00").content_hash
 
 
-def test_transaction_id_differs_on_amount_or_description():
-    baseline = _tx().transaction_id
-    assert _tx(amount="10.01").transaction_id != baseline
-    assert _tx(description="bar").transaction_id != baseline
-    assert _tx(currency="SGD").transaction_id != baseline
+def test_content_hash_differs_on_amount_or_description():
+    baseline = _tx().content_hash
+    assert _tx(amount="10.01").content_hash != baseline
+    assert _tx(description="bar").content_hash != baseline
+    assert _tx(currency="SGD").content_hash != baseline
 
 
-def test_transaction_id_not_in_str():
+def test_content_hash_not_in_str():
     tx = _tx(currency="SGD")
-    assert tx.transaction_id not in str(tx)
+    assert tx.content_hash not in str(tx)
 
 
-def test_transaction_id_reflects_later_mutation():
+def test_content_hash_reflects_later_mutation():
     # not cached: reading the id early must not freeze a stale value
     tx = _tx()
-    early = tx.transaction_id
+    early = tx.content_hash
     tx.currency = "SGD"
-    assert tx.transaction_id != early
+    assert tx.content_hash != early
 
 
 def test_balance_none_when_absent_float_when_present():


### PR DESCRIPTION
## What & why

The JSON `"id"` was a pure content hash — `sha256(date, description, amount, currency, account)` — so two **genuinely-distinct** transactions with identical fields (e.g. two identical same-day transfers) collided. A consumer keying on `id` (upsert / dedup / primary key) would silently drop one row of each pair. A scan of the real `Statements/` corpus found **5 such collisions across 3,246 transactions**.

## Approach

- **`serialize.assign_ids()`** is now the single sanctioned source of the per-row `id`: the bare `content_hash` for the first occurrence of a fingerprint, and `sha256((content_hash, n))` for the nth duplicate. Every non-duplicated `id` is **byte-identical to before**; only the 2nd+ member of a duplicate set changes.
- **`Transaction.transaction_id` → `content_hash`** (renamed), with a docstring making explicit it's a *content fingerprint that deliberately collides* — not a unique id. This closes the footgun where a future consumer (e.g. `--pprint`) grabs the colliding hash as an id.
- Single unique `id` kept over a `{id, occurrence}` composite, so a naive consumer keying on `id` alone stays correct — the right contract for an export format. `SCHEMA_VERSION` unchanged.

This matches established prior art (OFX `FITID`, YNAB's `import_id` occurrence ordinal, Firefly III's content-hash-as-fallback); running-balance and raw line-number tiebreaks were considered and rejected.

## Caveats (documented in `CLAUDE.md`)

- The occurrence ordinal is stable within one statement's row order but can't guarantee cross-statement stability if a bank re-sorts identical same-day rows — inherent to a stateless parser (it's *why* OFX invented FITID).
- Populating `account` (#308) folds a new field into `content_hash` and will rotate *every* id, not just duplicates.

## Verification

- **Real corpus:** collisions **5 → 0** across 3,246 transactions; all 3,236 uniquely-occurring baseline ids survive byte-identical.
- **Full gate:** ruff format/lint clean, `mypy src` clean, **198 passed / 0 failed / 0 skipped** — with git-crypt fixtures **unlocked**, so the bank integration tests genuinely ran against real statements.

## Commits

- `fix(serialize): give duplicate transactions distinct JSON ids`
- `docs: drop removed /commit skill from CLAUDE.md skills table`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
