### PR TITLE
refactor: model transaction kind as an enum; bundle parser fixture inputs

### DIFF
--- a/src/monopoly/constants/__init__.py
+++ b/src/monopoly/constants/__init__.py
@@ -3,6 +3,7 @@ from .statement import (
     Columns,
     EntryType,
     SharedPatterns,
+    TransactionKind,
 )
 
 __all__ = [
@@ -10,4 +11,5 @@ __all__ = [
     "Columns",
     "EntryType",
     "SharedPatterns",
+    "TransactionKind",
 ]

--- a/src/monopoly/constants/statement.py
+++ b/src/monopoly/constants/statement.py
@@ -1,6 +1,6 @@
 """Store statement-related enums and constants."""
 
-from enum import auto
+from enum import Enum, auto
 
 from strenum import StrEnum
 
@@ -10,6 +10,31 @@ from monopoly.enums import AutoEnum
 class EntryType(AutoEnum):
     CREDIT = auto()
     DEBIT = auto()
+
+
+class TransactionKind(Enum):
+    """
+    What a parsed row represents, and how it surfaces in the JSON envelope.
+
+    Each member owns its own serialization: ``balance_type`` is ``None`` for
+    real activity (which stays in ``transactions``) and the public ``type``
+    string for a carried-forward balance row (which ``serialize.py`` lifts into
+    the top-level ``balances`` list). Adding a new balance kind means adding a
+    member with its own type here - there is no separate lookup table to keep in
+    sync, and no way for an internal marker to leak out unmapped.
+    """
+
+    TRANSACTION = ("transaction", None)
+    PREVIOUS_BALANCE = ("previous_balance", "previous")
+
+    def __init__(self, marker: str, balance_type: str | None) -> None:
+        self._value_ = marker
+        self.balance_type = balance_type
+
+    @property
+    def is_balance(self) -> bool:
+        """True if this row is a balance carry-forward rather than real activity."""
+        return self.balance_type is not None
 
 
 class Columns(AutoEnum):

--- a/src/monopoly/constants/statement.py
+++ b/src/monopoly/constants/statement.py
@@ -14,14 +14,11 @@ class EntryType(AutoEnum):
 
 class TransactionKind(Enum):
     """
-    What a parsed row represents, and how it surfaces in the JSON envelope.
+    What a parsed row is, and how it serializes.
 
-    Each member owns its own serialization: ``balance_type`` is ``None`` for
-    real activity (which stays in ``transactions``) and the public ``type``
-    string for a carried-forward balance row (which ``serialize.py`` lifts into
-    the top-level ``balances`` list). Adding a new balance kind means adding a
-    member with its own type here - there is no separate lookup table to keep in
-    sync, and no way for an internal marker to leak out unmapped.
+    ``balance_type`` is ``None`` for real activity (stays in ``transactions``)
+    or the JSON ``type`` string for a balance row (lifted into ``balances``).
+    New balance kinds add a member here - no separate lookup table to sync.
     """
 
     TRANSACTION = ("transaction", None)

--- a/src/monopoly/pdf.py
+++ b/src/monopoly/pdf.py
@@ -1,6 +1,6 @@
 import logging
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import cached_property
 from io import BytesIO
 from pathlib import Path
@@ -124,38 +124,51 @@ class PdfDocument(Document):
         return "".join(page.get_text() for page in self)
 
 
+@dataclass
+class TextFixtureSource:
+    """
+    Pre-extracted page text standing in for a source PDF.
+
+    Backs `PdfParser.from_pages`: the text-fixture path has no PDF - and no PII -
+    so the pages, metadata and originating path (a fixture directory) that a
+    `PdfDocument` would otherwise supply are carried together here instead.
+    """
+
+    pages: list[PdfPage]
+    metadata: MetadataIdentifier = field(default_factory=MetadataIdentifier)
+    file_path: Path | None = None
+
+
 class PdfParser:
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         bank: type["BankBase"],
         document: PdfDocument | None = None,
         ocr_engine: str | None = None,
         *,
-        pages: list[PdfPage] | None = None,
-        metadata: MetadataIdentifier | None = None,
-        file_path: Path | None = None,
+        text_source: TextFixtureSource | None = None,
     ):
         """
         Class responsible for parsing PDFs and returning raw text.
 
-        The page_range variable determines which pages are extracted.
-        All pages are extracted by default.
-
-        A parser can also be built from pre-extracted page text (see
-        `from_pages`), in which case `document` is None and `pages` is
-        supplied directly. This backs the text-based fixture path, where the
-        source PDF - and its PII - is unavailable.
+        Supply a page source: a `document` (the normal path, which extracts text
+        and metadata from the PDF), or a `text_source` built from pre-extracted
+        page text (see `from_pages`). The page_range determines which pages are
+        extracted; all pages are extracted by default.
         """
+        if document is not None:
+            metadata_identifier = document.metadata_identifier
+        elif text_source is not None:
+            metadata_identifier = text_source.metadata
+        else:
+            msg = "provide either a document or text_source"
+            raise ValueError(msg)
+
         self.bank = bank
         self.document = document
         self.ocr_engine = ocr_engine
-        self._injected_pages = pages
-        self._file_path = file_path
-
-        if document is not None:
-            self.metadata_identifier = document.metadata_identifier
-        else:
-            self.metadata_identifier = metadata or MetadataIdentifier()
+        self._text_source = text_source
+        self.metadata_identifier = metadata_identifier
 
     @classmethod
     def from_pages(
@@ -174,14 +187,17 @@ class PdfParser:
         extracted (and redacted) text is available - not the original PDF.
         """
         pdf_pages = [page if isinstance(page, PdfPage) else PdfPage(page) for page in pages]
-        return cls(bank, document=None, pages=pdf_pages, metadata=metadata, file_path=file_path)
+        source = TextFixtureSource(pdf_pages, metadata or MetadataIdentifier(), file_path)
+        return cls(bank, text_source=source)
 
     @property
     def file_path(self) -> Path | None:
-        """Path of the source PDF, if the parser was built from one."""
+        """Path of the source PDF (or fixture directory), if one was supplied."""
         if self.document is not None:
             return self.document.file_path
-        return self._file_path
+        if self._text_source is not None:
+            return self._text_source.file_path
+        return None
 
     @property
     def pdf_config(self):
@@ -205,8 +221,8 @@ class PdfParser:
 
     @cached_property
     def pages(self):
-        if self._injected_pages is not None:
-            return self._injected_pages
+        if self._text_source is not None:
+            return self._text_source.pages
         return self._get_pages()
 
     def _get_pages(self) -> list[PdfPage]:

--- a/src/monopoly/serialize.py
+++ b/src/monopoly/serialize.py
@@ -25,9 +25,6 @@ from monopoly.statements.credit_statement import CreditStatement
 #     balance rows.
 SCHEMA_VERSION = 2
 
-# Turns the internal `kind` marker into the `type` value used in the JSON output.
-_BALANCE_KIND_TO_TYPE = {"previous_balance": "previous"}
-
 
 def _iso(value: date | datetime | None) -> str | None:
     """Coerce a date/datetime to an ISO date string, passing through None."""
@@ -48,9 +45,9 @@ def _payment_summary_to_dict(statement: BaseStatement) -> dict[str, Any] | None:
 
 
 def _balance_to_dict(transaction: Transaction) -> dict[str, Any]:
-    """Serialize a balance carry-forward row (kind != "transaction")."""
+    """Serialize a balance carry-forward row (kind.is_balance is True)."""
     return {
-        "type": _BALANCE_KIND_TO_TYPE.get(transaction.kind, transaction.kind),
+        "type": transaction.kind.balance_type,
         "amount": transaction.amount,
         "date": transaction.date,
         "direction": transaction.direction,
@@ -115,8 +112,8 @@ def statement_to_dict(statement: BaseStatement, transactions: list[Transaction])
     `transactions`, so `transactions` only holds real spending. The row still
     stays in the list internally; only the output separates them.
     """
-    activity = [tx for tx in transactions if tx.kind == "transaction"]
-    balances = [tx for tx in transactions if tx.kind != "transaction"]
+    activity = [tx for tx in transactions if not tx.kind.is_balance]
+    balances = [tx for tx in transactions if tx.kind.is_balance]
     return {
         "schema_version": SCHEMA_VERSION,
         "bank": statement.bank_name,

--- a/src/monopoly/statements/credit_statement.py
+++ b/src/monopoly/statements/credit_statement.py
@@ -2,7 +2,7 @@ import logging
 import re
 from functools import cached_property
 
-from monopoly.constants import EntryType
+from monopoly.constants import EntryType, TransactionKind
 from monopoly.statements.debit_statement import DebitStatement
 from monopoly.statements.payment_summary import PaymentSummary, PaymentSummaryExtractor
 from monopoly.statements.transaction import RawTransaction, Transaction
@@ -30,7 +30,7 @@ class CreditStatement(BaseStatement):
                 groupdict = prev_month_balance.groupdict()
                 groupdict["transaction_date"] = first_transaction_date
                 raw_transaction = RawTransaction(**groupdict)
-                prev_month_transaction = Transaction(**raw_transaction.as_dict(), kind="previous_balance")
+                prev_month_transaction = Transaction(**raw_transaction.as_dict(), kind=TransactionKind.PREVIOUS_BALANCE)
                 transactions.insert(0, prev_month_transaction)
         return transactions
 

--- a/src/monopoly/statements/transaction.py
+++ b/src/monopoly/statements/transaction.py
@@ -8,7 +8,7 @@ from pydantic import Field, field_validator, model_validator
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 from pydantic_core import ArgsKwargs
 
-from monopoly.constants import Columns
+from monopoly.constants import Columns, TransactionKind
 
 
 def strip_non_numeric(value: str) -> str:
@@ -84,7 +84,7 @@ class Transaction:
     posting_date: str | None = None
     currency: str | None = None
     account: str | None = None
-    kind: str = "transaction"
+    kind: TransactionKind = TransactionKind.TRANSACTION
     # avoid storing config logic, since the Transaction object is used to create
     # a single unique hash which should not change
     auto_direction: bool = Field(default=True, init=True, repr=False)

--- a/tests/unit/test_credit_statement.py
+++ b/tests/unit/test_credit_statement.py
@@ -2,6 +2,7 @@ import re
 from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
+from monopoly.constants import TransactionKind
 from monopoly.statements import CreditStatement, Transaction
 
 
@@ -78,14 +79,14 @@ def test_inject_prev_month_balance(credit_statement):
             description="bar",
             amount=-123.12,
             direction=None,
-            kind="previous_balance",
+            kind=TransactionKind.PREVIOUS_BALANCE,
         ),
         Transaction(
             transaction_date="2024-01-01",
             description="foo",
             amount=-99.99,
             direction=None,
-            kind="previous_balance",
+            kind=TransactionKind.PREVIOUS_BALANCE,
         ),
     ]
     assert result[0] in expected

--- a/tests/unit/test_serialize.py
+++ b/tests/unit/test_serialize.py
@@ -2,6 +2,7 @@ import json
 import re
 from datetime import datetime
 
+from monopoly.constants import TransactionKind
 from monopoly.serialize import SCHEMA_VERSION, assign_ids, statement_to_dict
 from monopoly.statements import Transaction
 
@@ -61,7 +62,7 @@ def test_previous_balance_routed_to_balances(credit_statement):
             amount="100.00",
             direction="DR",
             currency="SGD",
-            kind="previous_balance",
+            kind=TransactionKind.PREVIOUS_BALANCE,
         ),
         _tx(),
     ]


### PR DESCRIPTION
Two independent, behaviour-preserving refactors surfaced while reviewing the `json-prev-balance` work (now merged in #312). Output is byte-identical and the full suite passes.

## 1. `TransactionKind` enum owns its own serialization
The "what kind of row is this?" vocabulary was a bare `str` spelled three ways — `kind = "transaction"` (transaction.py), `kind="previous_balance"` (credit_statement.py), and `== "transaction"` / a `_BALANCE_KIND_TO_TYPE` lookup (serialize.py) — with nothing the type checker could police.

Replaced it with a `TransactionKind(Enum)` whose members carry their own behaviour: `balance_type` (`None` for real activity, else the public JSON `type` string) and an `is_balance` property. `serialize.py` now partitions and labels rows by asking the value itself. This also removes the `_BALANCE_KIND_TO_TYPE.get(kind, kind)` fallback, which would silently leak the internal marker into shipped JSON — a future balance kind without a declared public type is now unrepresentable rather than passed through raw.

## 2. `TextFixtureSource` for the parser's document-less path
`PdfParser.__init__` had grown a `# noqa: PLR0913`, six parameters, and an `if document is not None` branch because the text-fixture path threaded `pages`, `metadata` and `file_path` through the same constructor as the normal PDF path. Those three only ever appear together, and only when there is no source PDF, so they're now bundled into a `TextFixtureSource` value object.

`__init__` takes one page source (a `document` or a `text_source`), drops to four parameters (no `noqa`), and resolves metadata in a single narrowing branch. The `from_pages` / `file_path` public API is unchanged.

## Verification
- `ruff check` clean
- `mypy src` clean (81 files)
- `pytest` — 224 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)