### PR TITLE
fix(statements): centralise direction markers and column geometry

### DIFF
--- a/src/monopoly/constants/__init__.py
+++ b/src/monopoly/constants/__init__.py
@@ -1,4 +1,5 @@
 from .date import ISO8601
+from .direction import Direction
 from .statement import (
     Columns,
     EntryType,
@@ -9,6 +10,7 @@ from .statement import (
 __all__ = [
     "ISO8601",
     "Columns",
+    "Direction",
     "EntryType",
     "SharedPatterns",
     "TransactionKind",

--- a/src/monopoly/constants/direction.py
+++ b/src/monopoly/constants/direction.py
@@ -1,0 +1,48 @@
+"""The accounting direction of a transaction, and the raw markers that encode it."""
+
+from strenum import StrEnum
+
+
+class Direction(StrEnum):
+    """
+    Whether a transaction moves money in or out, as stored and serialized.
+
+    The values are the stored form: they appear verbatim in the JSON envelope
+    and in the `direction` CSV column, so they must not change without a
+    schema bump.
+    """
+
+    CREDIT = "credit"
+    DEBIT = "debit"
+
+    @classmethod
+    def parse(cls, marker: "str | Direction | None", *, minus: "Direction") -> "Direction | None":
+        r"""
+        Read the raw marker a statement prints beside an amount.
+
+        Statements annotate amounts with a short marker captured by
+        `SharedPatterns.DIRECTION` (``CR``, ``DR``, ``DB``, ``+``, ``-``).
+        This is the only place that knows that vocabulary.
+
+        `minus` names how a bare ``-`` reads, which genuinely differs by
+        statement type: credit statements print it on refunds (a credit),
+        debit statements on withdrawals (a debit). Callers pass their
+        `minus_direction`.
+
+        Returns `None` when there is no marker at all, leaving the direction
+        to be inferred downstream from the sign of the amount.
+        """
+        match marker:
+            case Direction():
+                return marker  # already parsed; keep parse() idempotent
+            case None | "":
+                return None
+            case "CR" | "+":
+                return cls.CREDIT
+            case "DR" | "DB":
+                return cls.DEBIT
+            case "-":
+                return minus
+            case _:
+                msg = f"Unsupported direction marker {marker!r}"
+                raise ValueError(msg)

--- a/src/monopoly/statements/base.py
+++ b/src/monopoly/statements/base.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import ClassVar
 
 from monopoly.config import MultilineConfig, StatementConfig
-from monopoly.constants import Columns, SharedPatterns
+from monopoly.constants import Columns, Direction, SharedPatterns
 from monopoly.pdf import PdfPage
 from monopoly.statements.date_resolver import DateResolver
 from monopoly.statements.number_extractor import NumberExtractor
@@ -125,6 +125,9 @@ class BaseStatement:
     """
 
     statement_type = "base"
+    #: How a bare "-" marker reads for this statement type. Debit statements
+    #: print it on withdrawals, credit statements on refunds.
+    minus_direction: ClassVar[Direction] = Direction.DEBIT
     columns: ClassVar[list[str]] = [
         Columns.DATE,
         Columns.DESCRIPTION,
@@ -209,6 +212,8 @@ class BaseStatement:
                 self.previous_transaction_date = raw_transaction.transaction_date
             else:
                 raw_transaction.transaction_date = self.previous_transaction_date
+
+        raw_transaction.direction = Direction.parse(raw_transaction.direction, minus=self.minus_direction)
         return raw_transaction
 
     def post_process_transactions(self, transactions: list[Transaction]) -> list[Transaction]:
@@ -240,11 +245,14 @@ class BaseStatement:
         24.02.25                       PAYMENT RECEIVED - THANK YOU            79.99
                                                                                   CR
 
-        In this case, the direction will resolve to CR.
+        In this case, the direction will resolve to Direction.CREDIT.
+
+        The next line must consist *only* of a marker; anything else is a
+        continuation of the statement body and leaves the direction unset.
         """
-        next_line = ctx.lines[ctx.idx + 1]
-        if re.match(SharedPatterns.DIRECTION, next_line):
-            return next_line.strip()
+        next_line = ctx.lines[ctx.idx + 1].strip()
+        if match := re.fullmatch(SharedPatterns.DIRECTION, next_line):
+            return Direction.parse(match.group("direction"), minus=self.minus_direction)
         return None
 
     @property

--- a/src/monopoly/statements/column_layout.py
+++ b/src/monopoly/statements/column_layout.py
@@ -1,0 +1,39 @@
+"""The withdrawal/deposit column geometry of a debit statement page."""
+
+from dataclasses import dataclass
+
+from monopoly.constants import Direction
+
+
+@dataclass(frozen=True)
+class ColumnLayout:
+    """
+    Character positions of the withdrawal and deposit columns on one page.
+
+    The two positions are only ever useful together — classifying an amount
+    needs both — so they are held as one value. A layout cannot be constructed
+    with only one column found, which removes the "withdrawal but no deposit"
+    state the caller would otherwise have to consider.
+    """
+
+    withdrawal: int
+    deposit: int
+
+    def classify(self, amount_end_pos: int) -> Direction:
+        """
+        Decide which column an amount sits under.
+
+        Amounts are right-aligned beneath their column heading, so the amount's
+        final character is compared against each heading's end position and the
+        nearer column wins.
+
+        e.g. with WITHDRAWAL ending at 40 and DEPOSIT at 55:
+        ```
+        DATE     DESCRIPTION          WITHDRAWAL         DEPOSIT
+        15 OCT   bill payment             322.07
+        16 OCT   item                                     123.12
+        ```
+        """
+        to_withdrawal = abs(amount_end_pos - self.withdrawal)
+        to_deposit = abs(amount_end_pos - self.deposit)
+        return Direction.CREDIT if to_withdrawal > to_deposit else Direction.DEBIT

--- a/src/monopoly/statements/credit_statement.py
+++ b/src/monopoly/statements/credit_statement.py
@@ -2,7 +2,7 @@ import logging
 import re
 from functools import cached_property
 
-from monopoly.constants import EntryType, TransactionKind
+from monopoly.constants import Direction, EntryType, TransactionKind
 from monopoly.statements.debit_statement import DebitStatement
 from monopoly.statements.payment_summary import PaymentSummary, PaymentSummaryExtractor
 from monopoly.statements.transaction import RawTransaction, Transaction
@@ -16,6 +16,7 @@ class CreditStatement(BaseStatement):
     """A dataclass representation of a credit statement."""
 
     statement_type = EntryType.CREDIT
+    minus_direction = Direction.CREDIT
 
     @cached_property
     def payment_summary(self) -> PaymentSummary:
@@ -33,13 +34,6 @@ class CreditStatement(BaseStatement):
                 prev_month_transaction = Transaction(**raw_transaction.as_dict(), kind=TransactionKind.PREVIOUS_BALANCE)
                 transactions.insert(0, prev_month_transaction)
         return transactions
-
-    def pre_process_match(self, raw_transaction: RawTransaction) -> RawTransaction:
-        """Pre-process transactions by adding a debit or credit direction identifier to the group dict."""
-        raw_transaction = super().pre_process_match(raw_transaction)
-        if raw_transaction.direction == "-":
-            raw_transaction.direction = "CR"
-        return raw_transaction
 
     def get_prev_month_balances(self) -> list[re.Match]:
         """

--- a/src/monopoly/statements/debit_statement.py
+++ b/src/monopoly/statements/debit_statement.py
@@ -1,7 +1,9 @@
 import logging
 import re
+from functools import cached_property
 
-from monopoly.constants import EntryType
+from monopoly.constants import Direction, EntryType
+from monopoly.statements.column_layout import ColumnLayout
 from monopoly.statements.transaction import RawTransaction
 
 from .base import BaseStatement, SafetyCheckError
@@ -13,87 +15,68 @@ class DebitStatement(BaseStatement):
     """A dataclass representation of a debit statement."""
 
     statement_type = EntryType.DEBIT
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._column_pos_cache: dict[tuple[str, int], int | None] = {}
+    minus_direction = Direction.DEBIT
 
     def pre_process_match(self, raw_transaction: RawTransaction) -> RawTransaction:
         """Pre-process transactions by adding a debit or credit direction identifier to the group dict."""
         raw_transaction = super().pre_process_match(raw_transaction)
-        page_number = raw_transaction.page_number
-        withdrawal_pos = self.get_withdrawal_pos(page_number)
-        deposit_pos = self.get_deposit_pos(page_number)
         direction = raw_transaction.direction
 
-        # If the transaction doesn't have an explicit direction, attempt to infer from column positions
-        if not direction and withdrawal_pos and deposit_pos:
-            direction = self.get_debit_direction(raw_transaction, withdrawal_pos, deposit_pos)
+        # No explicit marker: infer from which amount column the value sits under
+        if direction is None and (layout := self.column_layouts[raw_transaction.page_number]):
+            direction = layout.classify(self._amount_end_pos(raw_transaction))
 
-        match direction:
-            case "-" | "DR":
-                direction = "DR"
-            case "+" | "CR":
-                direction = "CR"
-            case None:
-                direction = "CR"  # default to credit
-            case _:
-                error = f"Unsupported direction type {direction}"
-                raise RuntimeError(error)
-
-        raw_transaction.direction = direction
+        raw_transaction.direction = direction or Direction.CREDIT  # default to credit
         return raw_transaction
 
-    def get_debit_direction(self, raw_transaction: RawTransaction, withdrawal_pos: int, deposit_pos: int) -> str:
+    @cached_property
+    def column_layouts(self) -> list[ColumnLayout | None]:
         """
-        Get the accounting direction for debit card statements.
+        The withdrawal/deposit geometry of each page, indexed by page number.
 
-        Attempts to identify whether a transaction is a debit
-        or credit entry based on the distance from the withdrawal
-        or deposit columns.
+        Computed once per statement. A page is `None` when either column is
+        missing from it, which is the same thing as having no usable geometry —
+        the two positions are only meaningful together.
         """
+        layouts: list[ColumnLayout | None] = []
+        for page_number in range(len(self.pages)):
+            withdrawal = self.get_withdrawal_pos(page_number)
+            deposit = self.get_deposit_pos(page_number)
+            layouts.append(None if withdrawal is None or deposit is None else ColumnLayout(withdrawal, deposit))
+        return layouts
+
+    @staticmethod
+    def _amount_end_pos(raw_transaction: RawTransaction) -> int:
+        """Amounts are right-aligned, so the final character is what locates the column."""
         if raw_transaction.match is None:
             msg = "RawTransaction.match is required for direction detection"
             raise ValueError(msg)
-        amount = raw_transaction.amount
         line = raw_transaction.match.string
-        start_pos = line.find(amount)
-        # assume that numbers are right aligned
-        end_pos = start_pos + len(amount) - 1
-        withdrawal_diff = abs(end_pos - withdrawal_pos)
-        deposit_diff = abs(end_pos - deposit_pos)
-        return "CR" if withdrawal_diff > deposit_diff else "DR"
+        return line.find(raw_transaction.amount) + len(raw_transaction.amount) - 1
 
     def get_withdrawal_pos(self, page_number: int) -> int | None:
         common_names = ["withdraw", "debit", r"from\ your\ account"]
         for name in common_names:
-            if pos := self.get_column_pos(name, page_number=page_number):
+            if (pos := self.get_column_pos(name, page_number=page_number)) is not None:
                 return pos
         logger.debug("%s column not found in header on page %s", common_names, page_number)
-        return False
+        return None
 
     def get_deposit_pos(self, page_number: int) -> int | None:
         common_names = ["deposit", "credit", r"to\ your\ account"]
         for name in common_names:
-            if pos := self.get_column_pos(name, page_number=page_number):
+            if (pos := self.get_column_pos(name, page_number=page_number)) is not None:
                 return pos
         logger.debug("%s column not found in header on page %s", common_names, page_number)
-        return False
+        return None
 
     def get_column_pos(self, column_type: str, page_number: int) -> int | None:
-        cache_key = (column_type, page_number)
-        if cache_key in self._column_pos_cache:
-            return self._column_pos_cache[cache_key]
-
         pattern = re.compile(rf"{column_type}[\w()$]*", re.IGNORECASE)
-        result = None
         if match := pattern.search(self.header):
-            result = self.get_header_pos(match.group(), page_number)
+            return self.get_header_pos(match.group(), page_number)
+        return None
 
-        self._column_pos_cache[cache_key] = result
-        return result
-
-    def get_header_pos(self, column_name: str, page_number: int) -> int:
+    def get_header_pos(self, column_name: str, page_number: int) -> int | None:
         """
         Return position of the 'WITHDRAWAL' or 'DEPOSIT' header for a particular page.
 
@@ -119,7 +102,7 @@ class DebitStatement(BaseStatement):
                 return header_start_pos + len(column_name)
 
         logger.debug("Debit header %s cannot be found on page %s", column_name, page_number)
-        return -1
+        return None
 
     def perform_safety_check(self: BaseStatement) -> bool:
         """Check that debit and credit transaction sums exist as a number within the statement."""

--- a/src/monopoly/statements/payment_summary.py
+++ b/src/monopoly/statements/payment_summary.py
@@ -6,6 +6,7 @@ from datetime import date
 from dateparser import parse
 
 from monopoly.config import StatementConfig
+from monopoly.constants import Direction
 from monopoly.pdf import PdfPage
 from monopoly.statements.transaction import strip_non_numeric
 
@@ -88,11 +89,15 @@ class PaymentSummaryExtractor:
         or with a trailing ``CR``/``-`` direction, both of which `strip_non_numeric`
         discards. Without this, a credit balance would be reported as a positive
         amount owed instead of a negative one.
+
+        A payment summary belongs to a credit statement, so a bare ``-`` here
+        reads as a credit.
         """
         if amount.strip().startswith("("):
             return True
         if "direction" in match.re.groupindex:
-            return match.group("direction") in ("CR", "-")
+            marker = Direction.parse(match.group("direction"), minus=Direction.CREDIT)
+            return marker is Direction.CREDIT
         return False
 
     def _extract_date(self, pattern) -> date | None:

--- a/src/monopoly/statements/transaction.py
+++ b/src/monopoly/statements/transaction.py
@@ -8,7 +8,7 @@ from pydantic import Field, field_validator, model_validator
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 from pydantic_core import ArgsKwargs
 
-from monopoly.constants import Columns, TransactionKind
+from monopoly.constants import Columns, Direction, TransactionKind
 
 
 def strip_non_numeric(value: str) -> str:
@@ -72,7 +72,7 @@ class Transaction:
     description: str
     amount: float
     date: str = Field(alias="transaction_date")
-    direction: str | None = None
+    direction: Direction | None = None
     # None means the statement has no balance column; distinct from a real 0.00
     # balance. The CSV writer still collapses None to 0; the JSON schema keeps null.
     balance: float | None = Field(default=None)
@@ -123,6 +123,19 @@ class Transaction:
             return strip_non_numeric(value)
         return str(value)
 
+    @field_validator(Columns.DIRECTION, mode="before")
+    def parse_direction_marker(cls, value: "str | Direction | None") -> Direction | None:
+        """
+        Coerce a raw marker to a `Direction`.
+
+        Statements normally parse the marker in `pre_process_match`, but
+        `CreditStatement.post_process_transactions` builds a `Transaction`
+        straight from the prev-balance groupdict and bypasses that. `minus` is
+        `DEBIT` here to preserve how a bare "-" has always been read at this
+        layer; statements resolve it against their own statement type first.
+        """
+        return Direction.parse(value, minus=Direction.DEBIT)
+
     # pylint: disable=bad-classmethod-argument
     @model_validator(mode="before")
     def treat_parenthesis_enclosure_as_credit(self: ArgsKwargs | Any) -> "ArgsKwargs":
@@ -130,25 +143,20 @@ class Transaction:
         if self.kwargs:
             amount: str = self.kwargs[Columns.AMOUNT]
             if isinstance(amount, str) and amount.startswith("(") and amount.endswith(")"):
-                self.kwargs[Columns.DIRECTION] = "CR"
+                self.kwargs[Columns.DIRECTION] = Direction.CREDIT
         return self
 
     @model_validator(mode="after")
     def normalize_direction_and_sign_amount(self: "Transaction") -> "Transaction":
         """
-        Sign the amount from the raw direction marker, then normalize the marker.
+        Sign the amount from the parsed direction, filling it in when absent.
 
-        `direction` arrives as a raw marker (CR/DR/DB/+/-/None). Credits are made
-        positive and debits negative (when auto_direction is on); the stored
-        direction is then rewritten to "credit"/"debit" so downstream consumers
-        (e.g. the JSON schema) never see raw, bank-specific markers.
+        `direction` has already been coerced to a `Direction` (or `None`) by
+        `parse_direction_marker`. Credits are made positive and debits negative
+        when `auto_direction` is on; an absent direction is then inferred from
+        the resulting sign so the field is never left unset.
         """
-        if self.direction in ("CR", "+"):
-            is_credit = True
-        elif self.direction in ("DR", "DB", "-"):
-            is_credit = False
-        else:
-            is_credit = None
+        is_credit = None if self.direction is None else self.direction is Direction.CREDIT
 
         # sign the amount (skip zero to avoid negative zero, and when disabled)
         if self.auto_direction and self.amount != 0:
@@ -157,7 +165,7 @@ class Transaction:
         # no explicit marker: fall back to the sign of the amount
         if is_credit is None:
             is_credit = self.amount >= 0
-        self.direction = "credit" if is_credit else "debit"
+        self.direction = Direction.CREDIT if is_credit else Direction.DEBIT
         return self
 
     def __str__(self):

--- a/src/monopoly/write.py
+++ b/src/monopoly/write.py
@@ -10,9 +10,16 @@ def generate_hash(statement: BaseStatement) -> str:
 
     Hashes an explicit list of the core transaction fields rather than the
     dataclass repr, so adding new fields to Transaction never churns filenames.
+
+    `direction` is coerced to a plain string: it is a `Direction` enum member,
+    whose repr is `<Direction.CREDIT: 'credit'>` rather than `'credit'`, and
+    letting that reach `repr()` would rewrite every generated filename.
     """
     hash_object = sha256()
-    identities = [(tx.date, tx.description, tx.amount, tx.direction, tx.balance) for tx in statement.transactions]
+    identities = [
+        (tx.date, tx.description, tx.amount, str(tx.direction) if tx.direction else None, tx.balance)
+        for tx in statement.transactions
+    ]
     hash_object.update(repr(identities).encode("utf-8"))
     return hash_object.hexdigest()[0:6]
 

--- a/tests/unit/test_column_layout.py
+++ b/tests/unit/test_column_layout.py
@@ -1,0 +1,72 @@
+import re
+
+import pytest
+
+from monopoly.config import DateOrder, StatementConfig
+from monopoly.constants import Direction, EntryType
+from monopoly.pdf import PdfPage
+from monopoly.statements import DebitStatement
+from monopoly.statements.column_layout import ColumnLayout
+
+LAYOUT = ColumnLayout(withdrawal=40, deposit=55)
+
+
+@pytest.mark.parametrize("end_pos", [38, 40, 42, 47])
+def test_amount_nearer_the_withdrawal_column_is_a_debit(end_pos):
+    assert LAYOUT.classify(end_pos) is Direction.DEBIT
+
+
+@pytest.mark.parametrize("end_pos", [48, 53, 55, 60])
+def test_amount_nearer_the_deposit_column_is_a_credit(end_pos):
+    assert LAYOUT.classify(end_pos) is Direction.CREDIT
+
+
+def test_equidistant_amount_resolves_to_debit():
+    """
+    The tie-break must stay on debit.
+
+    `get_debit_direction` returned CREDIT only when the withdrawal distance was
+    strictly greater, so an exactly-equidistant amount has always been read as
+    a withdrawal. Pinned here so the boundary cannot drift silently.
+    """
+    midpoint = (LAYOUT.withdrawal + LAYOUT.deposit) // 2
+    assert LAYOUT.classify(midpoint) is Direction.DEBIT
+
+
+def test_layout_at_column_zero_is_usable():
+    """A column starting at position 0 is a real layout, not a missing one."""
+    layout = ColumnLayout(withdrawal=0, deposit=20)
+    assert layout.classify(0) is Direction.DEBIT
+    assert layout.classify(20) is Direction.CREDIT
+
+
+def test_layout_is_frozen():
+    with pytest.raises(Exception, match="frozen|immutable|cannot assign"):
+        LAYOUT.withdrawal = 99
+
+
+def test_missing_header_on_page_yields_no_layout():
+    """
+    A column the page does not contain must not become position -1.
+
+    `get_header_pos` returned `-1` when the header line was absent from a given
+    page, and `-1` is truthy — so `get_withdrawal_pos`'s walrus returned it and
+    the old `withdrawal_pos and deposit_pos` gate accepted it. Every
+    transaction on such a page was then classified against (-1, -1), whose
+    distances are equal, forcing DEBIT regardless of the real column.
+    """
+    config = StatementConfig(
+        statement_type=EntryType.DEBIT,
+        header_pattern=re.compile(r"(WITHDRAWAL.*DEPOSIT.*BALANCE)"),
+        transaction_pattern=re.compile("foo"),
+        statement_date_pattern=re.compile(""),
+        transaction_date_order=DateOrder("DMY"),
+    )
+    # `header` was found on some other page; this page does not repeat it
+    page = PdfPage("15 OCT   bill payment             322.07\n")
+    statement = DebitStatement([page], "bank", config, "date description withdrawal deposit balance")
+
+    assert statement.get_header_pos("withdrawal", 0) is None
+    assert statement.get_withdrawal_pos(0) is None
+    assert statement.get_deposit_pos(0) is None
+    assert statement.column_layouts[0] is None

--- a/tests/unit/test_direction.py
+++ b/tests/unit/test_direction.py
@@ -1,0 +1,45 @@
+import pytest
+
+from monopoly.constants import Direction
+
+
+def test_stored_values_are_the_wire_format():
+    """`Direction` is a StrEnum, so members compare equal to their stored strings."""
+    assert Direction.CREDIT == "credit"
+    assert Direction.DEBIT == "debit"
+
+
+@pytest.mark.parametrize("marker", ["CR", "+"])
+def test_credit_markers(marker):
+    assert Direction.parse(marker, minus=Direction.DEBIT) is Direction.CREDIT
+
+
+@pytest.mark.parametrize("marker", ["DR", "DB"])
+def test_debit_markers(marker):
+    """`DB` is captured by SharedPatterns.DIRECTION and must not raise."""
+    assert Direction.parse(marker, minus=Direction.CREDIT) is Direction.DEBIT
+
+
+@pytest.mark.parametrize("marker", [None, ""])
+def test_absent_marker_defers_to_the_caller(marker):
+    assert Direction.parse(marker, minus=Direction.DEBIT) is None
+
+
+@pytest.mark.parametrize(
+    ("minus", "expected"),
+    [(Direction.DEBIT, Direction.DEBIT), (Direction.CREDIT, Direction.CREDIT)],
+)
+def test_minus_follows_the_statement_type(minus, expected):
+    """A bare '-' is a withdrawal on a debit statement, a refund on a credit one."""
+    assert Direction.parse("-", minus=minus) is expected
+
+
+@pytest.mark.parametrize("value", [Direction.CREDIT, Direction.DEBIT])
+def test_parse_is_idempotent(value):
+    """Re-parsing an already-parsed value returns it unchanged."""
+    assert Direction.parse(value, minus=Direction.DEBIT) is value
+
+
+def test_unknown_marker_raises():
+    with pytest.raises(ValueError, match="Unsupported direction marker 'XX'"):
+        Direction.parse("XX", minus=Direction.DEBIT)

--- a/tests/unit/test_statement_direction_multiline.py
+++ b/tests/unit/test_statement_direction_multiline.py
@@ -1,18 +1,50 @@
+import pytest
+
+from monopoly.constants import Direction
 from monopoly.statements.base import BaseStatement, MatchContext
 
 
-def test_multiline_direction_detected(statement: BaseStatement):
-    statement.pages[0].lines = [
-        "24.02.25  PAYMENT RECEIVED - THANK YOU            79.99",
-        "                                                  CR",
-    ]
-
-    context = MatchContext(
-        lines=statement.pages[0].lines,
-        line=statement.pages[0].lines[0],
+def _context(statement: BaseStatement, lines: list[str]) -> MatchContext:
+    statement.pages[0].lines = lines
+    return MatchContext(
+        lines=lines,
+        line=lines[0],
         description="PAYMENT RECEIVED - THANK YOU",
         idx=0,
     )
 
-    result = statement.get_multiline_direction(context)
-    assert result == "CR"
+
+def test_multiline_direction_detected(statement: BaseStatement):
+    context = _context(
+        statement,
+        [
+            "24.02.25  PAYMENT RECEIVED - THANK YOU            79.99",
+            "                                                  CR",
+        ],
+    )
+
+    assert statement.get_multiline_direction(context) is Direction.CREDIT
+
+
+@pytest.mark.parametrize(
+    "next_line",
+    [
+        "  CONTINUATION OF DESCRIPTION",
+        "                                                  -50.00",
+        "CR  AND THEN SOME MORE TEXT",
+        "",
+    ],
+)
+def test_next_line_that_is_not_a_bare_marker_is_ignored(statement: BaseStatement, next_line: str):
+    """
+    Only a line consisting solely of a marker sets the direction.
+
+    Anything else is statement body; leaving it unset lets the amount's sign
+    decide, which is what happened before the marker vocabulary was centralised.
+    """
+    context = _context(
+        statement,
+        ["24.02.25  PAYMENT RECEIVED - THANK YOU            79.99", next_line],
+    )
+
+    assert statement.get_multiline_direction(context) is None

--- a/tests/unit/test_statement_process_line.py
+++ b/tests/unit/test_statement_process_line.py
@@ -2,6 +2,7 @@ import re
 
 from monopoly.banks import Hsbc, Ocbc
 from monopoly.config import MultilineConfig
+from monopoly.constants import Direction
 from monopoly.pdf import PdfPage
 from monopoly.statements import BaseStatement
 from monopoly.statements.base import MatchContext
@@ -117,3 +118,45 @@ def test_process_match_multiline_description(statement: BaseStatement):
         "balance": None,
     }
     assert match.as_dict() == groupdict
+
+
+def test_db_marker_resolves_to_debit(debit_statement: BaseStatement):
+    """
+    A `DB` marker must parse, not crash.
+
+    `SharedPatterns.DIRECTION` has always captured `DB`, but the old `match`
+    block in `DebitStatement.pre_process_match` had no arm for it and fell
+    through to `RuntimeError` — before `Transaction`, which does understand it,
+    ever saw the value.
+    """
+    raw = RawTransaction(
+        match=re.search("foo", "foo"),
+        page_number=0,
+        transaction_date="04 Aug",
+        description="SHOPEE",
+        amount="3.20",
+        direction="DB",
+        balance=None,
+    )
+
+    processed = debit_statement.pre_process_match(raw)
+
+    assert processed.direction is Direction.DEBIT
+
+
+def test_db_marker_signs_the_amount_negative(debit_statement: BaseStatement):
+    """The parsed direction must still drive the sign through to Transaction."""
+    raw = RawTransaction(
+        match=re.search("foo", "foo"),
+        page_number=0,
+        transaction_date="04 Aug",
+        description="SHOPEE",
+        amount="3.20",
+        direction="DB",
+        balance=None,
+    )
+
+    transaction = Transaction(**debit_statement.pre_process_match(raw).as_dict())
+
+    assert transaction.direction is Direction.DEBIT
+    assert transaction.amount == -3.20


### PR DESCRIPTION
Two related defects in the statement layer, both from a shape the surrounding code kept working around. Plan: `.claude/plans/2026-09-05-direction-enum-column-layout.md`.

## 1. `DB` markers crashed

`SharedPatterns.DIRECTION` has always captured `CR|DR|DB|+|-`, and `Transaction` understands all five — but `DebitStatement.pre_process_match` had no `DB` arm and fell through to `RuntimeError("Unsupported direction type DB")`. It runs *first*, so `Transaction` never saw the marker it knows how to read. Confirmed against `main`:

```
main behaviour -> RuntimeError : Unsupported direction type DB
```

Five sites each carried their own copy of the marker vocabulary; two disagreed with the regex feeding them. This adds a `Direction` StrEnum that owns the table.

A bare `-` reads as **debit** on a debit statement and **credit** on a credit one. That rule is now a `minus_direction` ClassVar declared where it actually differs, rather than being spread across three files as an accident. Parsing moves into `BaseStatement`, so `CreditStatement.pre_process_match` is deleted outright.

## 2. A missing column header became position `-1`

`get_header_pos` returned `-1` when a page didn't repeat its header line — and `-1` is truthy, so `get_withdrawal_pos`'s walrus returned it and the `withdrawal_pos and deposit_pos` gate accepted it. Every transaction on such a page was classified against `(-1, -1)`, whose distances are equal, **forcing the whole page to DEBIT**.

The three functions involved disagreed on how to say "not found": `None`, `-1`, and `False` from a method annotated `int | None` — which is why mypy never caught it.

Adds a frozen `ColumnLayout` holding the pair, so "found one column but not the other" is unconstructable, and moves classification onto it (`get_debit_direction` never touched `self`). The per-`(column, page)` dict cache becomes a `cached_property` list indexed by page — the cached unit is the decision rather than two halves of one, and its lifetime is tied to the statement. (`functools.lru_cache` on the method would trip ruff B019 and pin every `DebitStatement`, and its pages, for the process lifetime.) That leaves `DebitStatement.__init__` a pure passthrough, so it is removed.

## Behaviour change

A header-less page previously produced DEBIT *by accident* via the `-1` leak; it now falls to the documented `Direction.CREDIT` default. **The 102-statement corpus does not exercise this path**, so it's latent rather than demonstrated safe — worth a reviewer's eye.

## Filename stability

`generate_hash` hashes `repr(identities)`, and `repr(Direction.CREDIT)` is `<Direction.CREDIT: 'credit'>`, not `'credit'` — typing the field as an enum silently rewrote every generated CSV filename (`test_generate_hash_pinned_and_field_independent` caught it, `374c20` → `efbec8`). Fixed by coercing with `str()` rather than re-pinning the test; that function's docstring makes filename stability an explicit contract.

## Verification

- ruff format (137 unchanged), ruff check clean, mypy clean (83 files)
- **254 passed / 0 failed / 0 skipped**
- `monopoly Statements -f json` over **102 real statements**, main vs branch: **81/81 byte-identical envelopes, identical filenames**. Output is unchanged because `Direction.CREDIT == "credit"` (StrEnum).
- Rebased onto `91a33e4` (post #313, `TransactionKind` + v2 `balances`). Only conflicts were two import lines. Gate and the 102-statement corpus comparison were both re-run against the new base.

## Noted, not fixed here

- The `verify` skill still documents the removed git-crypt `.gc_check` / `skip_if_encrypted` guard. Its check now reports "LOCKED" purely because the file is missing — a false negative. CLAUDE.md is already correct.
- The `debit_statement` test fixture passes `header_pattern="foo"` uncompiled, so `get_header_pos` raises `AttributeError` on it. Separate issue (the `Pattern | RegexEnum` union isn't normalised at the config boundary); tests here build the statement directly instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

