### PR TITLE
refactor(config): compile statement patterns once, at construction

### DIFF
--- a/src/monopoly/banks/base.py
+++ b/src/monopoly/banks/base.py
@@ -73,11 +73,7 @@ class BankBase:
                 raise TypeError(msg)
 
             pattern = config.transaction_pattern
-            actual_pattern = getattr(pattern, "regex", pattern)
-            group_index = getattr(actual_pattern, "groupindex", None)
-            if group_index is None:
-                continue
-            missing = required_groups - group_index.keys()
+            missing = required_groups - pattern.groupindex.keys()
             if missing:
                 msg = (
                     f"{cls.__name__}: transaction pattern {pattern!r} is missing "

--- a/src/monopoly/banks/dbs/dbs.py
+++ b/src/monopoly/banks/dbs/dbs.py
@@ -13,7 +13,7 @@ class Dbs(BankBase):
     credit = StatementConfig(
         currency="SGD",
         statement_type=EntryType.CREDIT,
-        statement_date_pattern=ISO8601.DD_MMM_YYYY,
+        statement_date_pattern=ISO8601.DD_MMM_YYYY.regex,
         header_pattern=re.compile(r"(DATE.*DESCRIPTION.*AMOUNT)"),
         transaction_date_format="%d %b",
         transaction_pattern=re.compile(
@@ -42,7 +42,7 @@ class Dbs(BankBase):
     debit = StatementConfig(
         currency="SGD",
         statement_type=EntryType.DEBIT,
-        statement_date_pattern=ISO8601.DD_MMM_YYYY,
+        statement_date_pattern=ISO8601.DD_MMM_YYYY.regex,
         multiline_config=MultilineConfig(
             multiline_descriptions=True,
             description_margin=10,  # Allow for indented PayNow/transaction details

--- a/src/monopoly/banks/maybank/maybank.py
+++ b/src/monopoly/banks/maybank/maybank.py
@@ -30,7 +30,7 @@ class Maybank(BankBase):
     my_credit = StatementConfig(
         currency="MYR",
         statement_type=EntryType.CREDIT,
-        statement_date_pattern=ISO8601.DD_MMM_YY,
+        statement_date_pattern=ISO8601.DD_MMM_YY.regex,
         header_pattern=re.compile(r"(Date.*Description.*Amount)"),
         transaction_date_format="%d/%m",
         transaction_pattern=re.compile(

--- a/src/monopoly/banks/ocbc/ocbc.py
+++ b/src/monopoly/banks/ocbc/ocbc.py
@@ -13,7 +13,7 @@ class Ocbc(BankBase):
     credit = StatementConfig(
         currency="SGD",
         statement_type=EntryType.CREDIT,
-        statement_date_pattern=ISO8601.DD_MM_YYYY,
+        statement_date_pattern=ISO8601.DD_MM_YYYY.regex,
         header_pattern=re.compile(r"(TRANSACTION DATE.*DESCRIPTION.*AMOUNT)"),
         prev_balance_pattern=re.compile(
             r"(?P<description>LAST MONTH'S BALANCE?)\s+" + SharedPatterns.AMOUNT_EXTENDED_WITHOUT_EOL

--- a/src/monopoly/config.py
+++ b/src/monopoly/config.py
@@ -1,10 +1,33 @@
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from re import Pattern
+from typing import ClassVar
 
 from monopoly.constants import EntryType
 from monopoly.enums import RegexEnum
 from monopoly.identifiers import IdentifierGroup
+
+
+def compile_pattern(value: "Pattern[str] | RegexEnum | str | None") -> "Pattern[str] | None":
+    """
+    Collapse any accepted spelling of a pattern to a compiled pattern.
+
+    Config authors may write a compiled pattern, a `RegexEnum` member, or a
+    bare regex string. Normalising here means every consumer downstream can
+    assume `re.Pattern` and just call `.search()`, rather than each re-deriving
+    the type with its own `isinstance` or `getattr` dance.
+    """
+    if value is None:
+        return None
+    if isinstance(value, RegexEnum):
+        return value.regex
+    if isinstance(value, str):
+        return re.compile(value)
+    if isinstance(value, Pattern):
+        return value
+    msg = f"Expected a compiled pattern, regex string or RegexEnum, got {type(value).__name__}: {value!r}"
+    raise TypeError(msg)
 
 
 @dataclass
@@ -49,9 +72,19 @@ class PaymentSummaryConfig:
     `amount` group, e.g. r"TOTAL AMOUNT DUE\s+(?P<amount>[\d,]+\.\d{2})".
     """
 
-    payment_due_date: Pattern[str] | RegexEnum | None = None
-    total_amount_due: Pattern[str] | RegexEnum | None = None
-    minimum_payment: Pattern[str] | RegexEnum | None = None
+    payment_due_date: Pattern[str] | None = None
+    total_amount_due: Pattern[str] | None = None
+    minimum_payment: Pattern[str] | None = None
+
+    PATTERN_FIELDS: ClassVar[tuple[str, ...]] = (
+        "payment_due_date",
+        "total_amount_due",
+        "minimum_payment",
+    )
+
+    def __post_init__(self) -> None:
+        for name in self.PATTERN_FIELDS:
+            setattr(self, name, compile_pattern(getattr(self, name)))
 
 
 # pylint: disable=too-many-instance-attributes
@@ -107,19 +140,32 @@ class StatementConfig:
     """
 
     statement_type: EntryType
-    transaction_pattern: Pattern[str] | RegexEnum
-    statement_date_pattern: Pattern[str] | RegexEnum
-    header_pattern: Pattern[str] | RegexEnum
+    transaction_pattern: Pattern[str]
+    statement_date_pattern: Pattern[str]
+    header_pattern: Pattern[str]
     transaction_date_order: DateOrder = field(default_factory=lambda: DateOrder("DMY"))
     statement_date_order: DateOrder = field(default_factory=lambda: DateOrder("DMY"))
     transaction_date_format: str = ""
     multiline_config: MultilineConfig = field(default_factory=MultilineConfig)
     transaction_bound: int | None = None
-    prev_balance_pattern: Pattern[str] | RegexEnum | None = None
+    prev_balance_pattern: Pattern[str] | None = None
     safety_check: bool = True
     transaction_auto_direction: bool = True
     filename_fallback_pattern: Pattern[str] | None = None
     payment_summary_config: PaymentSummaryConfig | None = None
+
+    PATTERN_FIELDS: ClassVar[tuple[str, ...]] = (
+        "transaction_pattern",
+        "statement_date_pattern",
+        "header_pattern",
+        "prev_balance_pattern",
+        "filename_fallback_pattern",
+    )
+
+    def __post_init__(self) -> None:
+        for name in self.PATTERN_FIELDS:
+            setattr(self, name, compile_pattern(getattr(self, name)))
+
     currency: str | None = None
 
 

--- a/src/monopoly/statements/base.py
+++ b/src/monopoly/statements/base.py
@@ -146,12 +146,9 @@ class BaseStatement:
         self.header = header
         self.file_path = file_path
 
-    @cached_property
-    def pattern(self):
-        pattern = self.config.transaction_pattern
-        if isinstance(pattern, str):
-            pattern = re.compile(pattern)
-        return pattern
+    @property
+    def pattern(self) -> re.Pattern[str]:
+        return self.config.transaction_pattern
 
     def get_transactions(self) -> list[Transaction] | None:
         transactions: list[Transaction] = []

--- a/src/monopoly/statements/date_resolver.py
+++ b/src/monopoly/statements/date_resolver.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from dateparser import parse
 
 from monopoly.config import StatementConfig
-from monopoly.constants.date import ISO8601
 from monopoly.exceptions import MissingStatementDateError
 from monopoly.pdf import PdfPage
 
@@ -32,11 +31,6 @@ class DateResolver:
     def resolve(self) -> datetime:
         """Find statement date from content, falling back to filename."""
         pattern = self.config.statement_date_pattern
-        allowed_patterns = (re.Pattern, ISO8601)
-
-        if not isinstance(pattern, allowed_patterns):
-            msg = f"Pattern must be one of {allowed_patterns}, not {type(pattern)}"
-            raise TypeError(msg)
 
         for page in self.pages:
             lines = page.lines

--- a/src/monopoly/statements/payment_summary.py
+++ b/src/monopoly/statements/payment_summary.py
@@ -62,8 +62,6 @@ class PaymentSummaryExtractor:
         """Return the first match of `pattern` across all page lines."""
         if not pattern:
             return None
-        if isinstance(pattern, str):
-            pattern = re.compile(pattern)
         for page in self.pages:
             for line in page.lines:
                 if match := pattern.search(line):

--- a/tests/unit/test_config_patterns.py
+++ b/tests/unit/test_config_patterns.py
@@ -1,0 +1,78 @@
+import re
+
+import pytest
+
+from monopoly.config import PaymentSummaryConfig, StatementConfig, compile_pattern
+from monopoly.constants import EntryType
+from monopoly.constants.date import ISO8601
+
+
+def _config(**overrides) -> StatementConfig:
+    defaults = {
+        "statement_type": EntryType.CREDIT,
+        "transaction_pattern": re.compile("foo"),
+        "statement_date_pattern": re.compile("bar"),
+        "header_pattern": re.compile("baz"),
+    }
+    return StatementConfig(**{**defaults, **overrides})
+
+
+class TestCompilePattern:
+    def test_string_is_compiled(self):
+        assert compile_pattern(r"\d+") == re.compile(r"\d+")
+
+    def test_regex_enum_yields_its_compiled_pattern(self):
+        assert compile_pattern(ISO8601.DD_MMM_YYYY) is ISO8601.DD_MMM_YYYY.regex
+
+    def test_compiled_pattern_passes_through_unchanged(self):
+        pattern = re.compile("already compiled")
+        assert compile_pattern(pattern) is pattern
+
+    def test_none_stays_none(self):
+        assert compile_pattern(None) is None
+
+    @pytest.mark.parametrize("value", [123, 4.5, object(), ["a"]])
+    def test_unsupported_type_raises_at_once(self, value):
+        with pytest.raises(TypeError, match="Expected a compiled pattern"):
+            compile_pattern(value)
+
+
+class TestStatementConfigNormalisation:
+    def test_every_spelling_lands_as_a_compiled_pattern(self):
+        config = _config(
+            transaction_pattern=r"(?P<description>.*)",
+            statement_date_pattern=ISO8601.DD_MMM_YYYY,
+            header_pattern=re.compile("HEADER"),
+        )
+
+        assert isinstance(config.transaction_pattern, re.Pattern)
+        assert isinstance(config.statement_date_pattern, re.Pattern)
+        assert isinstance(config.header_pattern, re.Pattern)
+
+    def test_optional_patterns_normalise_or_stay_none(self):
+        config = _config(prev_balance_pattern=r"PREVIOUS BALANCE")
+
+        assert isinstance(config.prev_balance_pattern, re.Pattern)
+        assert config.filename_fallback_pattern is None
+
+    def test_bad_pattern_fails_at_construction_not_at_use(self):
+        """
+        Validation used to be deferred to `DateResolver.resolve()`.
+
+        Failing in the constructor means a malformed bank config cannot be
+        built at import time, rather than surfacing mid-parse.
+        """
+        with pytest.raises(TypeError, match="Expected a compiled pattern"):
+            _config(statement_date_pattern=123)
+
+
+class TestPaymentSummaryConfigNormalisation:
+    def test_patterns_normalise(self):
+        config = PaymentSummaryConfig(
+            payment_due_date=r"DUE (?P<due_date>.*)",
+            total_amount_due=re.compile(r"TOTAL (?P<amount>.*)"),
+        )
+
+        assert isinstance(config.payment_due_date, re.Pattern)
+        assert isinstance(config.total_amount_due, re.Pattern)
+        assert config.minimum_payment is None

--- a/tests/unit/test_date_resolver.py
+++ b/tests/unit/test_date_resolver.py
@@ -109,15 +109,6 @@ class TestDateResolverResolve:
         with pytest.raises(ValueError, match="Statement date not found"):
             resolver.resolve()
 
-    def test_raises_for_invalid_pattern_type(self, basic_config):
-        """Test that TypeError is raised for invalid pattern type."""
-        basic_config.statement_date_pattern = "not a pattern"
-        pages = [PdfPage(raw_text="Statement Date: 15 Nov 2023")]
-        resolver = DateResolver(pages, basic_config)
-
-        with pytest.raises(TypeError, match="Pattern must be one of"):
-            resolver.resolve()
-
     def test_filename_fallback_when_content_has_no_date(self, filename_fallback_config):
         """Test that filename fallback is used when content has no date."""
         pages = [PdfPage(raw_text="No date in content")]


### PR DESCRIPTION
Plate 01 of the structural-revisions set. Independent of #314 — no overlapping files except `statements/base.py`, in different methods.

## The problem

Every pattern field was typed `Pattern[str] | RegexEnum`, so the union travelled all the way to the leaves and **four** consumers each re-derived the concrete type — with **three** different ideas of what's valid:

| Site | How it coped | Accepts |
|---|---|---|
| `banks/base.py` | `getattr(pattern, "regex", pattern)` then `getattr(..., "groupindex", None)` | anything; **silently skips validation** when the attribute is absent |
| `statements/base.py` | `isinstance(pattern, str)` + `re.compile` | `str`, `Pattern` |
| `payment_summary.py` | the same check again | `str`, `Pattern` |
| `date_resolver.py` | `isinstance(pattern, (re.Pattern, ISO8601))` else `TypeError` | **rejects** the bare strings the other two accept |

## The change

`StatementConfig` and `PaymentSummaryConfig` normalise in `__post_init__` through a shared `compile_pattern`, which takes a compiled pattern, a `RegexEnum` member or a regex string, and rejects anything else. All four coping sites are deleted; the fields are annotated `re.Pattern[str]`, so mypy sees a concrete type downstream rather than a union.

`BaseStatement.pattern` drops from `cached_property` to a plain property — there's nothing left to cache once the compile happens in the config.

## Two consequences worth a reviewer's eye

**Validation moved from mid-parse to construction.** A malformed bank config now fails at import instead of when a statement happens to reach the resolver. This makes `test_raises_for_invalid_pattern_type` obsolete in an interesting way: its input, `"not a pattern"`, is a perfectly valid regex, so under the new contract it isn't an error at all. Replaced with construction-time tests that use genuinely non-pattern values.

**Four bank configs now pass `.regex`.** `dbs` (×2), `maybank` and `ocbc` passed a bare `ISO8601` member; they now pass `ISO8601.X.regex` so the narrowed annotation holds without `type: ignore`. Runtime coercion stays, because fixtures (13 sites) and third-party configs still pass bare strings.

## Verification

- ruff format, ruff check, mypy clean (81 source files)
- **235 passed / 0 failed / 0 skipped**
- `monopoly Statements -f json` over **102 real statements**, main vs branch: **81/81 byte-identical envelopes, identical filenames**

Note CI reports no checks on this repo (Actions billing), so the pre-commit gate and the above are the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)