### PR TITLE
refactor(statements): share safety reconciliation, make BaseStatement abstract

### DIFF
--- a/src/monopoly/statements/base.py
+++ b/src/monopoly/statements/base.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
 from functools import cached_property
@@ -117,7 +118,7 @@ class DescriptionBuilder:
         return abs(pos1 - pos2) <= margin
 
 
-class BaseStatement:
+class BaseStatement(ABC):
     """
     A dataclass representation of a bank statement.
 
@@ -265,10 +266,9 @@ class BaseStatement:
         resolver = DateResolver(self.pages, self.config, self.file_path)
         return resolver.resolve()
 
+    @abstractmethod
     def perform_safety_check(self) -> bool:
-        """Mandate the perform_safety_check method, which should exist in any child class of Statement."""
-        msg = "Subclasses must implement perform_safety_check method"
-        raise NotImplementedError(msg)
+        """Validate that the extracted transactions reconcile against the statement."""
 
     def get_all_numbers_from_document(self) -> set[float]:
         """

--- a/src/monopoly/statements/base.py
+++ b/src/monopoly/statements/base.py
@@ -120,7 +120,7 @@ class DescriptionBuilder:
 
 class BaseStatement(ABC):
     """
-    A dataclass representation of a bank statement.
+    Abstract base for a bank statement.
 
     Contains PDF pages (their raw text representation in a list), and specific bank config.
     """

--- a/src/monopoly/statements/credit_statement.py
+++ b/src/monopoly/statements/credit_statement.py
@@ -3,8 +3,8 @@ import re
 from functools import cached_property
 
 from monopoly.constants import Direction, EntryType, TransactionKind
-from monopoly.statements.debit_statement import DebitStatement
 from monopoly.statements.payment_summary import PaymentSummary, PaymentSummaryExtractor
+from monopoly.statements.safety import sums_reconcile
 from monopoly.statements.transaction import RawTransaction, Transaction
 
 from .base import BaseStatement, SafetyCheckError
@@ -69,10 +69,10 @@ class CreditStatement(BaseStatement):
         if abs(total_amount) in numbers or total_amount_found:
             return True
 
-        # attempt a debit-statement style safety for banks that have
-        # debit and credit amounts as separate numbers and not a single total sum
-        logger.debug("Running debit statement safety check for credit statement")
-        if DebitStatement.perform_safety_check(self):
+        # some banks print debits and credits as separate figures rather than
+        # a single net total, so fall back to reconciling the two sums
+        logger.debug("Falling back to debit-style reconciliation")
+        if sums_reconcile(transactions, numbers | {0.0}):
             return True
 
         msg = f"Total amount {total_amount} cannot be found in credit statement"

--- a/src/monopoly/statements/credit_statement.py
+++ b/src/monopoly/statements/credit_statement.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class CreditStatement(BaseStatement):
-    """A dataclass representation of a credit statement."""
+    """A credit statement."""
 
     statement_type = EntryType.CREDIT
     minus_direction = Direction.CREDIT

--- a/src/monopoly/statements/debit_statement.py
+++ b/src/monopoly/statements/debit_statement.py
@@ -4,6 +4,7 @@ from functools import cached_property
 
 from monopoly.constants import Direction, EntryType
 from monopoly.statements.column_layout import ColumnLayout
+from monopoly.statements.safety import sums_reconcile
 from monopoly.statements.transaction import RawTransaction
 
 from .base import BaseStatement, SafetyCheckError
@@ -104,24 +105,12 @@ class DebitStatement(BaseStatement):
         logger.debug("Debit header %s cannot be found on page %s", column_name, page_number)
         return None
 
-    def perform_safety_check(self: BaseStatement) -> bool:
+    def perform_safety_check(self) -> bool:
         """Check that debit and credit transaction sums exist as a number within the statement."""
-        transactions = self.transactions
+        # zero covers statements that are entirely debits or entirely credits
+        numbers = self.get_all_numbers_from_document() | {0.0}
 
-        numbers = self.get_all_numbers_from_document()
-
-        # add a zero, for cases where the debit statement
-        # either is completely debit or credit transactions
-        numbers.update([0])
-
-        debit_amounts = [transaction.amount for transaction in transactions if transaction.amount > 0]
-        credit_amounts = [transaction.amount for transaction in transactions if transaction.amount < 0]
-
-        debit_sum = round(abs(sum(debit_amounts)), 2)
-        credit_sum = round(abs(sum(credit_amounts)), 2)
-
-        result = all([debit_sum in numbers, credit_sum in numbers])
-        if not result:
+        if not sums_reconcile(self.transactions, numbers):
             raise SafetyCheckError(self.failed_safety_message)
 
-        return result
+        return True

--- a/src/monopoly/statements/debit_statement.py
+++ b/src/monopoly/statements/debit_statement.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class DebitStatement(BaseStatement):
-    """A dataclass representation of a debit statement."""
+    """A debit statement."""
 
     statement_type = EntryType.DEBIT
     minus_direction = Direction.DEBIT

--- a/src/monopoly/statements/safety.py
+++ b/src/monopoly/statements/safety.py
@@ -1,0 +1,16 @@
+"""Reconciliation shared by the debit and credit safety checks."""
+
+from monopoly.statements.transaction import Transaction
+
+
+def sums_reconcile(transactions: list[Transaction], numbers: set[float]) -> bool:
+    """
+    Report whether the debit and credit totals both appear in the document.
+
+    Used where a statement prints its debits and credits as two separate
+    figures rather than one net total. A pure predicate: callers decide what
+    a failure means and which error to raise.
+    """
+    debit_total = round(abs(sum(t.amount for t in transactions if t.amount > 0)), 2)
+    credit_total = round(abs(sum(t.amount for t in transactions if t.amount < 0)), 2)
+    return debit_total in numbers and credit_total in numbers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from monopoly.config import DateOrder, PdfConfig, StatementConfig
 from monopoly.constants import EntryType
 from monopoly.handler import StatementHandler
 from monopoly.pdf import PdfDocument, PdfPage, PdfParser
+from test_utils.statements import ConcreteStatement
 from monopoly.statements import BaseStatement, CreditStatement, DebitStatement
 
 
@@ -87,7 +88,7 @@ def debit_statement(statement_config):
 
 @pytest.fixture(scope="function")
 def statement(statement_config):
-    yield from setup_statement_fixture(BaseStatement, statement_config)
+    yield from setup_statement_fixture(ConcreteStatement, statement_config)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from monopoly.config import DateOrder, PdfConfig, StatementConfig
 from monopoly.constants import EntryType
 from monopoly.handler import StatementHandler
 from monopoly.pdf import PdfDocument, PdfPage, PdfParser
-from test_utils.statements import ConcreteStatement
+from test_utils.statements import StubStatement
 from monopoly.statements import BaseStatement, CreditStatement, DebitStatement
 
 
@@ -88,7 +88,7 @@ def debit_statement(statement_config):
 
 @pytest.fixture(scope="function")
 def statement(statement_config):
-    yield from setup_statement_fixture(ConcreteStatement, statement_config)
+    yield from setup_statement_fixture(StubStatement, statement_config)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_utils/statements.py
+++ b/tests/test_utils/statements.py
@@ -1,0 +1,14 @@
+from monopoly.statements import BaseStatement
+
+
+class ConcreteStatement(BaseStatement):
+    """
+    Minimal concrete statement for tests exercising `BaseStatement` itself.
+
+    `BaseStatement` is abstract, so it cannot be instantiated directly. Tests
+    covering shared behaviour (multiline handling, match processing, naming)
+    need an instance without caring how safety checks work.
+    """
+
+    def perform_safety_check(self) -> bool:
+        return True

--- a/tests/test_utils/statements.py
+++ b/tests/test_utils/statements.py
@@ -1,13 +1,14 @@
 from monopoly.statements import BaseStatement
 
 
-class ConcreteStatement(BaseStatement):
+class StubStatement(BaseStatement):
     """
-    Minimal concrete statement for tests exercising `BaseStatement` itself.
+    Minimal instantiable `BaseStatement` for tests of shared base behaviour.
 
     `BaseStatement` is abstract, so it cannot be instantiated directly. Tests
     covering shared behaviour (multiline handling, match processing, naming)
-    need an instance without caring how safety checks work.
+    need an instance without caring how safety checks work, so the one abstract
+    method is stubbed with a canned pass.
     """
 
     def perform_safety_check(self) -> bool:

--- a/tests/unit/test_safety_reconcile.py
+++ b/tests/unit/test_safety_reconcile.py
@@ -48,7 +48,10 @@ class TestBaseStatementIsAbstract:
             statement_date_pattern=re.compile("bar"),
             header_pattern=re.compile("baz"),
         )
-        with pytest.raises(TypeError, match="abstract method 'perform_safety_check'"):
+        # Message wording differs across Python versions (3.11 omits the quotes
+        # and says "with abstract method"; 3.12+ says "without an implementation
+        # for abstract method '...'"), so match only the stable substring.
+        with pytest.raises(TypeError, match="abstract method '?perform_safety_check'?"):
             BaseStatement(pages=[], bank_name="bank", config=config, header="")
 
 

--- a/tests/unit/test_safety_reconcile.py
+++ b/tests/unit/test_safety_reconcile.py
@@ -1,0 +1,75 @@
+import re
+
+import pytest
+
+from monopoly.config import StatementConfig
+from monopoly.constants import EntryType
+from monopoly.pdf import PdfPage
+from monopoly.statements import BaseStatement, CreditStatement, Transaction
+from monopoly.statements.base import SafetyCheckError
+from monopoly.statements.safety import sums_reconcile
+
+
+def _tx(amount: float) -> Transaction:
+    return Transaction(transaction_date="01/01", description="x", amount=amount, auto_direction=False)
+
+
+class TestSumsReconcile:
+    def test_both_totals_present_reconciles(self):
+        transactions = [_tx(10.0), _tx(20.0), _tx(-5.0)]
+        assert sums_reconcile(transactions, {30.0, 5.0}) is True
+
+    def test_missing_credit_total_does_not_reconcile(self):
+        assert sums_reconcile([_tx(10.0), _tx(-5.0)], {10.0}) is False
+
+    def test_missing_debit_total_does_not_reconcile(self):
+        assert sums_reconcile([_tx(10.0), _tx(-5.0)], {5.0}) is False
+
+    def test_one_sided_statement_needs_zero_present(self):
+        """An all-debit statement has a credit total of 0, which must be in the set."""
+        assert sums_reconcile([_tx(10.0)], {10.0}) is False
+        assert sums_reconcile([_tx(10.0)], {10.0, 0.0}) is True
+
+    def test_totals_are_rounded_to_two_places(self):
+        assert sums_reconcile([_tx(0.1), _tx(0.2)], {0.3, 0.0}) is True
+
+
+class TestBaseStatementIsAbstract:
+    def test_cannot_be_instantiated(self):
+        """
+        The safety check is now enforced at construction, not at call time.
+
+        It was previously a `raise NotImplementedError` body, which only fired
+        once a statement had already been parsed.
+        """
+        config = StatementConfig(
+            statement_type=EntryType.CREDIT,
+            transaction_pattern=re.compile("foo"),
+            statement_date_pattern=re.compile("bar"),
+            header_pattern=re.compile("baz"),
+        )
+        with pytest.raises(TypeError, match="abstract method 'perform_safety_check'"):
+            BaseStatement(pages=[], bank_name="bank", config=config, header="")
+
+
+class TestCreditFallbackMessage:
+    def test_credit_specific_message_now_surfaces(self):
+        """
+        The credit message used to be unreachable.
+
+        `CreditStatement` called `DebitStatement.perform_safety_check(self)`,
+        which *raises* rather than returning False — so its generic message
+        pre-empted the more informative credit one. Now that the fallback is a
+        pure predicate, the credit branch reports its own failure.
+        """
+        config = StatementConfig(
+            statement_type=EntryType.CREDIT,
+            transaction_pattern=re.compile("foo"),
+            statement_date_pattern=re.compile("bar"),
+            header_pattern=re.compile("baz"),
+        )
+        statement = CreditStatement([PdfPage("Statement Page 1\nno totals listed here\n")], "bank", config, "header")
+        statement.transactions = [_tx(10.0), _tx(20.0)]
+
+        with pytest.raises(SafetyCheckError, match="Total amount 30.0 cannot be found in credit statement"):
+            statement.perform_safety_check()

--- a/tests/unit/test_transaction_multiline_date.py
+++ b/tests/unit/test_transaction_multiline_date.py
@@ -1,6 +1,6 @@
 import re
 from monopoly.config import MultilineConfig, StatementConfig, EntryType
-from monopoly.statements.base import BaseStatement
+from test_utils.statements import ConcreteStatement
 from monopoly.statements.transaction import RawTransaction
 
 
@@ -21,7 +21,7 @@ def test_carry_forward_date_when_multiline_is_enabled():
         header_pattern=".*",
         transaction_auto_direction=True,
     )
-    statement = BaseStatement(pages=[], bank_name="Test Bank", config=config, header="")
+    statement = ConcreteStatement(pages=[], bank_name="Test Bank", config=config, header="")
 
     # SCENARIO: Process a sequence of transactions
     first_date = "24 FEB 2025"
@@ -67,7 +67,7 @@ def test_date_is_not_carried_forward_when_multiline_is_disabled():
         statement_type=EntryType.CREDIT,
         transaction_auto_direction=True,
     )
-    statement = BaseStatement(pages=[], bank_name="Test Bank", config=config, header="")
+    statement = ConcreteStatement(pages=[], bank_name="Test Bank", config=config, header="")
     dummy_match = re.search("foo", "foo")
 
     # SCENARIO: Process two transactions

--- a/tests/unit/test_transaction_multiline_date.py
+++ b/tests/unit/test_transaction_multiline_date.py
@@ -1,6 +1,6 @@
 import re
 from monopoly.config import MultilineConfig, StatementConfig, EntryType
-from test_utils.statements import ConcreteStatement
+from test_utils.statements import StubStatement
 from monopoly.statements.transaction import RawTransaction
 
 
@@ -21,7 +21,7 @@ def test_carry_forward_date_when_multiline_is_enabled():
         header_pattern=".*",
         transaction_auto_direction=True,
     )
-    statement = ConcreteStatement(pages=[], bank_name="Test Bank", config=config, header="")
+    statement = StubStatement(pages=[], bank_name="Test Bank", config=config, header="")
 
     # SCENARIO: Process a sequence of transactions
     first_date = "24 FEB 2025"
@@ -67,7 +67,7 @@ def test_date_is_not_carried_forward_when_multiline_is_disabled():
         statement_type=EntryType.CREDIT,
         transaction_auto_direction=True,
     )
-    statement = ConcreteStatement(pages=[], bank_name="Test Bank", config=config, header="")
+    statement = StubStatement(pages=[], bank_name="Test Bank", config=config, header="")
     dummy_match = re.search("foo", "foo")
 
     # SCENARIO: Process two transactions


### PR DESCRIPTION
Plate 03 of the structural-revisions set.

## The sibling borrow

`CreditStatement.perform_safety_check` called `DebitStatement.perform_safety_check(self)` — an unbound call with a `CreditStatement` as `self`. That's why the debit method was annotated `def perform_safety_check(self: BaseStatement)`: the signature was apologising for the trick, and `credit_statement.py` imported its own sibling to pull it off.

The shared logic — *do the debit and credit sums each appear somewhere in the document?* — moves to `statements/safety.py` as `sums_reconcile`, a pure predicate. Both classes call it and decide for themselves what failure means. The sibling import and the odd `self` annotation both go.

## This makes a dead error message reachable

Worth a reviewer's attention, because it's a behaviour change I didn't set out to make.

The borrowed method **raises** rather than returning `False`. So when a credit statement failed both checks, the debit method's generic message fired first and `credit_statement.py`'s own `raise` was unreachable. Verified against main before changing anything:

```
message raised -> Safety check failed - transactions may be inaccurate
credit-specific message reachable? False
```

With a predicate as the fallback, the credit branch now reports `Total amount X cannot be found in credit statement`. **Only the message changes** — which statements pass or fail is identical. No test asserted the old string (they only assert `pytest.raises(SafetyCheckError)`), and a new test pins the new one.

## BaseStatement is now abstract

`perform_safety_check` was a `raise NotImplementedError` body, which could only fire *after* a statement had been parsed. It's now `@abstractmethod` on an `ABC`, so a subclass missing it fails at construction.

`BaseStatement` is instantiated directly in tests, so the `statement` fixture and two tests in `test_transaction_multiline_date.py` now use a minimal `ConcreteStatement` in `tests/test_utils/` — the house location for shared test helpers.

## Verification

- ruff format, ruff check, mypy clean (84 source files)
- **272 passed / 0 failed / 0 skipped**
- `monopoly Statements -f json` over **102 real statements**, main vs branch: **81/81 byte-identical envelopes, identical filenames**

CI reports no checks on this repo (Actions billing), so the pre-commit gate and the above are the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)