### PR TITLE
ci: speed up workflows (drop ocrmypdf, cache uv, cancel stale runs)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: ubuntu-latest
@@ -12,13 +16,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Install pdftotext
+      # pdftotext is an sdist-only C extension, so libpoppler-cpp-dev is needed to
+      # build it. gcc/pkg-config are preinstalled on the runner; ocrmypdf is a
+      # lazy, optional runtime dep that no lint/type/test job exercises.
+      - name: Install pdftotext build deps
         run: |
           sudo apt-get update
-          sudo apt-get install build-essential libpoppler-cpp-dev pkg-config ocrmypdf
+          sudo apt-get install -y libpoppler-cpp-dev
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
 
       - name: Set up Python
         run: uv python install

--- a/.github/workflows/performance.yaml
+++ b/.github/workflows/performance.yaml
@@ -2,6 +2,10 @@ name: performance
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   perf-test:
     runs-on: ubuntu-22.04
@@ -11,10 +15,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      # pdftotext is an sdist-only C extension, so libpoppler-cpp-dev is needed to
+      # build it. gcc/pkg-config are preinstalled; ocrmypdf is unused by the benchmark.
       - name: Install pdftotext dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libpoppler-cpp-dev pkg-config ocrmypdf
+          sudo apt-get install -y libpoppler-cpp-dev
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v7
@@ -23,6 +29,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
 
       - name: Install hyperfine
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
     runs-on: ubuntu-22.04
@@ -15,10 +19,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      # pdftotext is an sdist-only C extension, so libpoppler-cpp-dev is needed to
+      # build it (and provides the runtime lib). gcc/pkg-config are preinstalled;
+      # ocrmypdf is a lazy, optional runtime dep and the OCR tests are fully mocked.
       - name: Install pdftotext dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential libpoppler-cpp-dev pkg-config ocrmypdf
+          sudo apt-get install -y libpoppler-cpp-dev
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7
@@ -27,6 +34,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## What

The `apt-get install ... ocrmypdf` step was ~50s of a ~70s CI job — the dominant cost across `ci`, all four `tests` matrix legs, and `performance`. The actual test run is only ~9s.

## Changes

- **Drop `ocrmypdf` (+ `build-essential`/`pkg-config`) from the apt install.** `ocrmypdf` is a *lazy, optional* runtime import (`src/monopoly/pdf.py:314`, guarded by try/except that just warns "ocrmypdf not installed"), and both OCR tests (`test_ocr_available.py`, `test_gemini_ocr.py`) are fully mocked — no CI job ever shells out to it. It drags in tesseract + ghostscript + qpdf, which is where the time went. `gcc`/`pkg-config` are preinstalled on GitHub runners, so only `libpoppler-cpp-dev` remains (needed to build the sdist-only `pdftotext` C extension).
- **Enable `astral-sh/setup-uv` cache.** `pdftotext` ships no wheels, so uv recompiled it from sdist on every run (and every matrix leg). Caching compiles it once and restores the wheel thereafter.
- **Add `concurrency` groups** so a new push cancels superseded in-flight runs.

## Notes

- No third-party apt-cache action — plain `apt-get`, and the only cache added is on the official astral action.
- Caveat: a cached `pdftotext` wheel is linked to a libpoppler ABI; if the runner image bumps libpoppler, busting the uv cache fixes any import error. Low risk on stable `ubuntu-22.04`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)