### PR TITLE
fix(statements): initialise carried date, drop dead and unreachable code

### DIFF
--- a/src/monopoly/statements/base.py
+++ b/src/monopoly/statements/base.py
@@ -43,19 +43,15 @@ class DescriptionBuilder:
     WORDS_PATTERN: ClassVar[re.Pattern] = re.compile(r"\s[A-Za-z]+")
     NUMBERS_PATTERN: ClassVar[re.Pattern] = re.compile(SharedPatterns.AMOUNT)
 
-    def __init__(self, ctx: MatchContext, pattern: re.Pattern):
+    def __init__(self, ctx: MatchContext, pattern: re.Pattern, cfg: MultilineConfig):
         self.pattern = pattern
         self.ctx = ctx
-        self.cfg = ctx.multiline_config
+        self.cfg = cfg
         self.description = ctx.description
         self.desc_pos = ctx.line.find(ctx.description)
-        self.previous_transaction_date = None
 
     def build(self) -> str:
         """Build the final description string by iterating forward through lines."""
-        if not self.cfg:
-            return self.description
-
         # Handle previous line
         if self.cfg.include_prev_margin and self.ctx.idx > 0:
             self._include_previous_line()
@@ -70,10 +66,6 @@ class DescriptionBuilder:
 
     def _should_break(self, line: str) -> bool:
         """Determine if processing should stop at the current line."""
-        # cfg is guaranteed to be not None here because build() returns early if cfg is None
-        if self.cfg is None:
-            return True
-
         if not line.strip() or self.pattern.search(line):
             return True
 
@@ -95,10 +87,6 @@ class DescriptionBuilder:
 
     def _include_previous_line(self) -> None:
         """Attempt to prepend the previous line."""
-        # cfg is guaranteed to be not None here because build() returns early if cfg is None
-        if self.cfg is None:
-            return
-
         prev_line = self.ctx.lines[self.ctx.idx - 1].strip()
         if not prev_line or self.pattern.search(prev_line):
             return
@@ -150,6 +138,8 @@ class BaseStatement(ABC):
         self.pages = pages
         self.header = header
         self.file_path = file_path
+        # carried across lines when multiline_transaction_date is enabled
+        self.previous_transaction_date: str | None = None
 
     @property
     def pattern(self) -> re.Pattern[str]:
@@ -226,7 +216,7 @@ class BaseStatement(ABC):
             match.direction = self.get_multiline_direction(context)
 
         if config.multiline_descriptions:
-            match.description = DescriptionBuilder(context, self.pattern).build()
+            match.description = DescriptionBuilder(context, self.pattern, config).build()
 
         return match
 

--- a/src/monopoly/statements/number_extractor.py
+++ b/src/monopoly/statements/number_extractor.py
@@ -1,10 +1,13 @@
 """Number extraction logic for statement safety checks."""
 
 import re
-from functools import cached_property
 
 from monopoly.constants import Columns, SharedPatterns
 from monopoly.pdf import PdfPage
+
+_NUMBER_RE = re.compile(r"[\d.,]+")
+_DECIMAL_RE = re.compile(r"\d+\.\d+$")
+_SUBTOTAL_RE = re.compile(rf"(?:sub\stotal.*?)\s+{SharedPatterns.AMOUNT}", re.IGNORECASE)
 
 
 class NumberExtractor:
@@ -12,18 +15,6 @@ class NumberExtractor:
 
     def __init__(self, pages: list[PdfPage]):
         self.pages = pages
-
-    @cached_property
-    def _number_pattern(self) -> re.Pattern:
-        return re.compile(r"[\d.,]+")
-
-    @cached_property
-    def _decimal_pattern(self) -> re.Pattern:
-        return re.compile(r"\d+\.\d+$")
-
-    @cached_property
-    def _subtotal_pattern(self) -> re.Pattern:
-        return re.compile(rf"(?:sub\stotal.*?)\s+{SharedPatterns.AMOUNT}", re.IGNORECASE)
 
     def get_all_numbers(self) -> set[float]:
         """Extract all decimal numbers from all pages plus subtotal sums."""
@@ -41,9 +32,9 @@ class NumberExtractor:
         """
         numbers: set[str] = set()
         for line in lines:
-            numbers.update(self._number_pattern.findall(line))
+            numbers.update(_NUMBER_RE.findall(line))
         numbers = {number.replace(",", "") for number in numbers}
-        return {float(number) for number in numbers if self._decimal_pattern.match(number)}
+        return {float(number) for number in numbers if _DECIMAL_RE.match(number)}
 
     def _get_subtotal_sum(self) -> float:
         """
@@ -55,9 +46,7 @@ class NumberExtractor:
         subtotals: list[str] = []
         for page in self.pages:
             subtotals.extend(
-                match.groupdict()[Columns.AMOUNT]
-                for line in page.lines
-                if (match := self._subtotal_pattern.search(line))
+                match.groupdict()[Columns.AMOUNT] for line in page.lines if (match := _SUBTOTAL_RE.search(line))
             )
         cleaned_subtotals = [float(amount.replace(",", "")) for amount in subtotals]
         return sum(cleaned_subtotals)

--- a/src/monopoly/statements/transaction.py
+++ b/src/monopoly/statements/transaction.py
@@ -56,10 +56,6 @@ class RawTransaction:
             "balance": self.balance,
         }
 
-    def span(self):
-        """Return the span of the regex match."""
-        return self.match.span()
-
 
 @pydantic_dataclass
 class Transaction:

--- a/tests/unit/test_number_extractor.py
+++ b/tests/unit/test_number_extractor.py
@@ -3,7 +3,12 @@
 import pytest
 
 from monopoly.pdf import PdfPage
-from monopoly.statements.number_extractor import NumberExtractor
+from monopoly.statements.number_extractor import (
+    _DECIMAL_RE,
+    _NUMBER_RE,
+    _SUBTOTAL_RE,
+    NumberExtractor,
+)
 
 
 class TestNumberExtractorGetDecimalNumbers:
@@ -158,12 +163,11 @@ class TestNumberExtractorGetAllNumbers:
 
 
 class TestNumberExtractorPatterns:
-    """Tests for NumberExtractor regex pattern properties."""
+    """Tests for the module-level regex constants."""
 
     def test_number_pattern_matches_digits_and_separators(self):
         """Test that number pattern matches expected formats."""
-        extractor = NumberExtractor(pages=[])
-        pattern = extractor._number_pattern
+        pattern = _NUMBER_RE
 
         assert pattern.search("123.45")
         assert pattern.search("1,234.56")
@@ -171,8 +175,7 @@ class TestNumberExtractorPatterns:
 
     def test_decimal_pattern_requires_decimal_point(self):
         """Test that decimal pattern requires decimal point at end."""
-        extractor = NumberExtractor(pages=[])
-        pattern = extractor._decimal_pattern
+        pattern = _DECIMAL_RE
 
         assert pattern.match("123.45")
         assert pattern.match("0.5")
@@ -181,8 +184,7 @@ class TestNumberExtractorPatterns:
 
     def test_subtotal_pattern_matches_subtotal_lines(self):
         """Test that subtotal pattern matches 'sub total' lines."""
-        extractor = NumberExtractor(pages=[])
-        pattern = extractor._subtotal_pattern
+        pattern = _SUBTOTAL_RE
 
         assert pattern.search("sub total 100.00")
         assert pattern.search("SUB TOTAL 1,234.56")

--- a/tests/unit/test_transaction_multiline_date.py
+++ b/tests/unit/test_transaction_multiline_date.py
@@ -80,3 +80,26 @@ def test_date_is_not_carried_forward_when_multiline_is_disabled():
 
     # 3. ASSERT: The date should remain None because the feature is off
     assert result.transaction_date is None, "Date should not be carried forward when the feature is disabled"
+
+
+def test_first_match_without_a_date_carries_nothing_forward():
+    """
+    A statement may open on a continuation line with no date of its own.
+
+    `previous_transaction_date` used to be initialised on `DescriptionBuilder`
+    — which never read it — and not on the statement that does, so reaching
+    this path raised `AttributeError` before any transaction was returned.
+    """
+    config = StatementConfig(
+        multiline_config=MultilineConfig(multiline_transaction_date=True),
+        transaction_pattern=".*",
+        statement_date_pattern=".*",
+        header_pattern=".*",
+        statement_type=EntryType.CREDIT,
+    )
+    statement = StubStatement(pages=[], bank_name="Test Bank", config=config, header="")
+
+    raw = RawTransaction(description="CONTINUED LINE", amount="3.20", transaction_date=None)
+    processed = statement.pre_process_match(raw)
+
+    assert processed.transaction_date is None


### PR DESCRIPTION
Four items from the appendix sheet. **`ocr_available` is deliberately untouched** — see the correction at the bottom.

## A.1 — the carried date lived on the wrong object *(live crash)*

`previous_transaction_date` was initialised by `DescriptionBuilder.__init__`, which never reads it, and read/written by `BaseStatement.pre_process_match`, which never initialises it. A statement whose *first* matched line carries no `transaction_date` raised `AttributeError` before returning any transaction.

Reachable for **bmo**, **cibc** and **rbc**, which enable `multiline_transaction_date`. The new regression test fails on main with exactly:

```
AttributeError: 'StubStatement' object has no attribute 'previous_transaction_date'
```

## A.2 — guards against a `None` that cannot arrive

`build()` returned early when `cfg` was falsy, and is the only caller of `_should_break` and `_include_previous_line` — yet both re-checked `self.cfg is None`, each above a comment explaining the check was unreachable. `DescriptionBuilder` now takes a non-optional `MultilineConfig` supplied by `process_match`, which had already established the fact. Three checks and two apologetic comments go.

## A.3 — `RawTransaction.span()`

Zero callers in `src` or `tests`, and it dereferences `self.match`, whose declared default is `None`. Deleted.

## A.5 — constant regexes memoised per instance

`NumberExtractor` wrapped three constant patterns in `cached_property` despite none of them reading `self`, while the neighbouring `generic/patterns.py` hoists the same kind of constant to module level. Now consistent with the neighbour. Its tests point at the constants directly.

## Verification

- ruff format, ruff check, mypy clean (85 source files)
- **290 passed / 0 failed / 0 skipped**
- `monopoly Statements -f json` over **102 real statements**, main vs branch: **81/81 byte-identical envelopes, identical filenames**

🤖 Generated with [Claude Code](https://claude.com/claude-code)