### PR TITLE
feat(gemini): set TransactionKind on the vision path

### DIFF
--- a/src/monopoly/gemini.py
+++ b/src/monopoly/gemini.py
@@ -1,12 +1,25 @@
 import json
 import logging
+import re
 from datetime import datetime
 
+from monopoly.constants import TransactionKind
 from monopoly.llm import GeminiSettings, MissingApiKeyError
 from monopoly.pdf import PdfDocument
 from monopoly.statements.transaction import Transaction
 
 logger = logging.getLogger(__name__)
+
+# Safety net for when the model omits the "kind" marker: the wordings the native
+# parsers' per-bank ``prev_balance_pattern`` use for carried-over prior balances.
+_PREV_BALANCE_RE = re.compile(
+    r"""(?ix)
+      last\s+month'?s\s+balance
+    | previous\s+(statement\s+)?balance
+    | balance\s+(previous\s+statement|from\s+previous\s+statement|brought\s+forward)
+    | outstanding\s+balance\s+brought\s+forward
+    """
+)
 
 EXTRACTION_PROMPT = """\
 Extract all transactions from this bank statement image.
@@ -20,7 +33,8 @@ Return a JSON object with exactly this structure:
     {
       "date": "YYYY-MM-DD",
       "description": "merchant or description",
-      "amount": -12.34
+      "amount": -12.34,
+      "kind": "transaction"
     }
   ]
 }
@@ -31,11 +45,32 @@ Rules:
 - statement_type: "credit" for credit card statements, "debit" for bank account/savings/current account statements
 - amount: negative for debits/purchases, positive for credits/payments/refunds
 - date: the transaction date (not the posting date)
-- Include "Previous Statement Balance" or similar balance carry-forward lines as transactions \
+- kind: "transaction" for normal activity, or "previous_balance" for a carried-over prior \
+statement balance line (e.g. "Previous Statement Balance", "Last Month's Balance", \
+"Balance Brought Forward"). Default to "transaction" when unsure.
+- Include the carried-over prior balance line as a row with "kind": "previous_balance" \
 (use the statement start date as the date). These are needed for totals to balance.
 - Ignore other non-transaction lines (headers, footers, summaries, fine print)
 - Return ONLY the JSON object, no markdown fences or commentary
 """
+
+
+def _resolve_kind(description: str, raw_kind: str | None) -> TransactionKind:
+    """
+    Map the model's ``kind`` marker to a :class:`TransactionKind`.
+
+    Trusts an explicit marker, but falls back to matching the description against
+    the known carry-forward wordings so a model miss doesn't silently regress a
+    previous-balance row into ordinary activity.
+    """
+    if raw_kind:
+        try:
+            return TransactionKind(raw_kind)
+        except ValueError:
+            logger.warning("Unknown transaction kind %r from Gemini; treating as transaction", raw_kind)
+    if _PREV_BALANCE_RE.search(description or ""):
+        return TransactionKind.PREVIOUS_BALANCE
+    return TransactionKind.TRANSACTION
 
 
 class GeminiResult:
@@ -109,6 +144,7 @@ class GeminiParser:
                 description=tx["description"],
                 amount=float(tx["amount"]),
                 auto_direction=False,
+                kind=_resolve_kind(tx["description"], tx.get("kind")),
             )
             transactions.append(transaction)
 

--- a/src/monopoly/gemini.py
+++ b/src/monopoly/gemini.py
@@ -16,8 +16,7 @@ _PREV_BALANCE_RE = re.compile(
     r"""(?ix)
       last\s+month'?s\s+balance
     | previous\s+(statement\s+)?balance
-    | balance\s+(previous\s+statement|from\s+previous\s+statement|brought\s+forward)
-    | outstanding\s+balance\s+brought\s+forward
+    | balance\s+((from\s+)?previous\s+statement|brought\s+forward)
     """
 )
 

--- a/src/monopoly/gemini.py
+++ b/src/monopoly/gemini.py
@@ -20,6 +20,8 @@ _PREV_BALANCE_RE = re.compile(
     """
 )
 
+_KIND_BY_MARKER = {kind.value: kind for kind in TransactionKind}
+
 EXTRACTION_PROMPT = """\
 Extract all transactions from this bank statement image.
 
@@ -63,10 +65,9 @@ def _resolve_kind(description: str, raw_kind: str | None) -> TransactionKind:
     previous-balance row into ordinary activity.
     """
     if raw_kind:
-        try:
-            return TransactionKind(raw_kind)
-        except ValueError:
-            logger.warning("Unknown transaction kind %r from Gemini; treating as transaction", raw_kind)
+        if kind := _KIND_BY_MARKER.get(raw_kind):
+            return kind
+        logger.warning("Unknown transaction kind %r from Gemini; treating as transaction", raw_kind)
     if _PREV_BALANCE_RE.search(description or ""):
         return TransactionKind.PREVIOUS_BALANCE
     return TransactionKind.TRANSACTION

--- a/tests/unit/test_gemini_parser.py
+++ b/tests/unit/test_gemini_parser.py
@@ -3,7 +3,8 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
-from monopoly.gemini import GeminiParser, GeminiResult, MissingApiKeyError
+from monopoly.constants import TransactionKind
+from monopoly.gemini import GeminiParser, GeminiResult, MissingApiKeyError, _resolve_kind
 
 
 @pytest.fixture
@@ -93,3 +94,73 @@ def test_parse_strips_markdown_fences(mock_google_genai):
 
     assert len(result.transactions) == 1
     assert result.transactions[0].description == "GROCERY"
+
+
+def _parse_single(mock_google_genai, response_text):
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.text = response_text
+    mock_client.models.generate_content.return_value = mock_response
+    mock_google_genai.Client.return_value = mock_client
+
+    mock_page = MagicMock()
+    mock_pixmap = MagicMock()
+    mock_pixmap.tobytes.return_value = b"fake-png-bytes"
+    mock_page.get_pixmap.return_value = mock_pixmap
+
+    mock_document = MagicMock()
+    mock_document.__iter__ = Mock(return_value=iter([mock_page]))
+
+    return GeminiParser(api_key="test-key").parse(mock_document)
+
+
+def test_parse_honors_explicit_kind_marker(mock_google_genai):
+    result = _parse_single(
+        mock_google_genai,
+        """{
+            "statement_date": "2026-06-21",
+            "bank_name": "ocbc",
+            "transactions": [
+                {"date": "2026-05-21", "description": "LAST MONTH'S BALANCE", "amount": -946.13,
+                 "kind": "previous_balance"},
+                {"date": "2026-05-22", "description": "COFFEE SHOP", "amount": -5.00, "kind": "transaction"}
+            ]
+        }""",
+    )
+    assert result.transactions[0].kind is TransactionKind.PREVIOUS_BALANCE
+    assert result.transactions[0].kind.is_balance
+    assert result.transactions[1].kind is TransactionKind.TRANSACTION
+
+
+def test_parse_falls_back_to_description_when_kind_missing(mock_google_genai):
+    """The model may omit the marker; the description safety net still tags it."""
+    result = _parse_single(
+        mock_google_genai,
+        """{
+            "statement_date": "2026-06-21",
+            "bank_name": "ocbc",
+            "transactions": [
+                {"date": "2026-05-21", "description": "LAST MONTH'S BALANCE", "amount": -946.13},
+                {"date": "2026-05-22", "description": "COFFEE SHOP", "amount": -5.00}
+            ]
+        }""",
+    )
+    assert result.transactions[0].kind is TransactionKind.PREVIOUS_BALANCE
+    assert result.transactions[1].kind is TransactionKind.TRANSACTION
+
+
+@pytest.mark.parametrize(
+    ("description", "raw_kind", "expected"),
+    [
+        ("COFFEE SHOP", "transaction", TransactionKind.TRANSACTION),
+        ("LAST MONTH'S BALANCE", "previous_balance", TransactionKind.PREVIOUS_BALANCE),
+        ("PREVIOUS STATEMENT BALANCE", None, TransactionKind.PREVIOUS_BALANCE),
+        ("BALANCE BROUGHT FORWARD", None, TransactionKind.PREVIOUS_BALANCE),
+        ("COFFEE SHOP", None, TransactionKind.TRANSACTION),
+        # An unknown marker degrades safely to the description check, not a crash.
+        ("COFFEE SHOP", "nonsense", TransactionKind.TRANSACTION),
+        ("LAST MONTH'S BALANCE", "nonsense", TransactionKind.PREVIOUS_BALANCE),
+    ],
+)
+def test_resolve_kind(description, raw_kind, expected):
+    assert _resolve_kind(description, raw_kind) is expected


### PR DESCRIPTION
Closes #323

## Problem

Since 0.23.0, carry-forward rows are tagged first-class via `TransactionKind` / `tx.kind.is_balance` — but only on the **native regex-parser path**. `GeminiParser` built every `Transaction` with the default `kind`, so on the vision path:

- `tx.kind.is_balance` was always `False`, even for a `LAST MONTH'S BALANCE` / `PREVIOUS STATEMENT BALANCE` row;
- the v2 JSON schema mis-filed those rows into `transactions` instead of `balances`;
- downstream consumers were pushed back to string-matching descriptions to identify carry-forward rows.

## Change

- Add a `kind` field to the extraction schema and ask the model to classify carry-forward lines as `"previous_balance"` (default `"transaction"`).
- Map the marker via a new `_resolve_kind` helper, with a **description-based safety net** (the same wordings the banks' `prev_balance_pattern` use) so a model miss doesn't silently regress a balance row into ordinary activity. An unknown/garbage marker degrades to the description check rather than raising.

Scoped to `kind` only — richer metadata (`direction`/`balance`/`currency`) is intentionally left out, since a scan can't reliably reconstruct running balances.

## Tests

- `test_parse_honors_explicit_kind_marker` — explicit `"previous_balance"` / `"transaction"` markers are respected.
- `test_parse_falls_back_to_description_when_kind_missing` — safety net tags a carry-forward row when the model omits `kind`.
- `test_resolve_kind` — parametrized over explicit, missing, and unknown markers.

Full unit suite: 222 passed. ruff + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)